### PR TITLE
fix: add support for exposing functions that return objects

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -305,3 +305,21 @@ test("isMarshalable option", async () => {
   arena.dispose();
   vm.dispose();
 });
+
+test("expose function that returns object", async () => {
+  const vm = (await getQuickJS()).createVm();
+  const arena = new Arena(vm);
+
+  arena.expose({
+    makeObject: () => {
+      return {
+        myFavoriteNumber: 42,
+      };
+    },
+  });
+
+  expect(arena.evalCode(`makeObject().myFavoriteNumber`)).toBe(42);
+
+  arena.dispose();
+  vm.dispose();
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,16 +193,13 @@ export class Arena {
       return registered;
     }
 
-    const map = new VMMap(this.vm);
-    map.merge(this._map);
-
     const handle = marshal(this._wrap(target) ?? target, {
       vm: this.vm,
       unmarshal: (h) => this._unmarshal(h),
       isMarshalable: (t) =>
         this._options?.isMarshalable?.(this._unwrap(t)) ?? true,
-      find: (t) => this._registeredMap.get(t) ?? map.get(t),
-      pre: (t, h) => this._register(t, h, map)?.[1],
+      find: (t) => this._registeredMap.get(t) ?? this._map.get(t),
+      pre: (t, h) => this._register(t, h, this._map)?.[1],
       preApply: (target, that, args) => {
         const unwrapped = isObject(that) ? this._unwrap(that) : undefined;
         // override sync mode of this object while calling the function
@@ -216,9 +213,6 @@ export class Arena {
       },
     });
 
-    this._map.merge(map);
-    map.clear();
-    map.dispose();
     return handle;
   }
 

--- a/src/vmmap.ts
+++ b/src/vmmap.ts
@@ -85,10 +85,6 @@ export default class VMMap {
     }
 
     this.vm.newNumber(counter).consume((c) => {
-      if (!this._mapSet.alive) {
-        throw new Error("VMMap::set: `this._mapSet` is not alive!");
-      }
-
       this._call(
         this._mapSet,
         undefined,

--- a/src/vmmap.ts
+++ b/src/vmmap.ts
@@ -85,6 +85,10 @@ export default class VMMap {
     }
 
     this.vm.newNumber(counter).consume((c) => {
+      if (!this._mapSet.alive) {
+        throw new Error("VMMap::set: `this._mapSet` is not alive!");
+      }
+
       this._call(
         this._mapSet,
         undefined,


### PR DESCRIPTION
I've been experimenting with this library and ran into a problem which is best illustrated with this simple test:

```ts
test("expose function that returns object", async () => {
  const vm = (await getQuickJS()).createVm();
  const arena = new Arena(vm);

  arena.expose({
    makeObject: () => {
      return {
        myFavoriteNumber: 42,
      };
    },
  });

  expect(arena.evalCode(`makeObject().myFavoriteNumber`)).toBe(42);

  arena.dispose();
  vm.dispose();
});
```

While attempting to call `evalCode`, a `Lifetime not alive` error is thrown. I [traced the issue](https://github.com/reearth/quickjs-emscripten-sync/commit/203f8ae14f8390a0516b9380a6064a3f0dce8138) to an instance where `VMMap::_mapSet` was attempting to be called in the VM but was not alive.

I believe the `_mapSet` instance was no longer alive because the original `VMMap` used to marshal the return value was created ephemerally here:

https://github.com/reearth/quickjs-emscripten-sync/blob/21a7fd81803be76c7e3a605ab11c79ceffb13e04/src/index.ts#L196-L197

Then, it is merged with the `Arena::map` instance again before it is disposed via `.dispose()`, here:

https://github.com/reearth/quickjs-emscripten-sync/blob/21a7fd81803be76c7e3a605ab11c79ceffb13e04/src/index.ts#L219-L221

Then, some time after the ephemeral map is disposed of, a callback passed to `.consume` must be executed and at this point `_mapSet` has already been disposed:

https://github.com/reearth/quickjs-emscripten-sync/blob/203f8ae14f8390a0516b9380a6064a3f0dce8138/src/vmmap.ts#L87-L102

To get around this, I'm avoiding the creation of the ephemeral map entirely, and instead I'm pointing directly to the `Arena::map` instance.

This fixed the issue and didn't appear to cause any new test failures, but I'm not certain this change is actually safe and would love to know what you think.

Thank you for your help, and for sharing your hard work - your library has been a pleasure to work with. 🙇‍♂️