### PR TITLE
fix: add option to disable sync mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "build": "tsc && vite build",
+    "prepare": "vite build",
     "test": "vitest",
     "lint": "eslint .",
     "format": "prettier --write \"./src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\""

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "build": "tsc && vite build",
     "test": "vitest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "format": "prettier --write \"./src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\""
   },
   "peerDependencies": {
     "quickjs-emscripten": "*"

--- a/src/index.ts
+++ b/src/index.ts
@@ -334,10 +334,10 @@ export class Arena {
       target,
       this._symbol,
       this._symbolHandle,
-      this._options?.syncEnabled ?? true,
       this._marshal,
       this._syncMode,
       this._options?.isWrappable,
+      this._options?.syncEnabled ?? true,
     );
   }
 
@@ -356,10 +356,10 @@ export class Arena {
       handle,
       this._symbol,
       this._symbolHandle,
-      this._options?.syncEnabled ?? true,
       this._unmarshal,
       this._syncMode,
       this._options?.isHandleWrappable,
+      this._options?.syncEnabled ?? true,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export type Options = {
   compat?: boolean;
   /** Experimental: use QuickJSContextEx, which wraps existing QuickJSContext. */
   experimentalContextEx?: boolean;
-  /** Globally enable syncing mode, If returns false, If returns false, note that the handle cannot be synchronized between the host and the QuickJS even if arena.sync is used.  */
+  /** Globally enable syncing mode. Default is true. If returns false, note that the handle cannot be synchronized between the host and the QuickJS even if arena.sync is used.  */
   syncEnabled?: boolean;
 };
 

--- a/src/memory.test.ts
+++ b/src/memory.test.ts
@@ -1,0 +1,108 @@
+import { getQuickJS } from "quickjs-emscripten";
+import { describe, expect, test } from "vitest";
+
+import { Arena } from ".";
+
+describe("memory", () => {
+  test("memory leak", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, {
+      isMarshalable: true,
+      registeredObjects: [],
+      syncEnabled: false,
+    });
+
+    const getMemory = () => {
+      const handle = ctx.runtime.computeMemoryUsage();
+      const mem = ctx.dump(handle);
+      handle.dispose();
+      return mem;
+    };
+
+    arena.expose({
+      fnFromHost: () => {
+        return {
+          id: "some id",
+          data: Math.random(),
+        };
+      },
+    });
+
+    arena.evalCode(`globalThis.test = {
+      check: () => {
+        return fnFromHost();
+      }
+    }`);
+
+    const memoryBefore = getMemory().memory_used_size as number;
+    const data = arena.evalCode("globalThis.test.check()");
+    expect(data).not.toBeNull();
+
+    for (let i = 0; i < 100; i++) {
+      const data = arena.evalCode("globalThis.test.check()");
+      expect(data).not.toBeNull();
+    }
+
+    const memoryAfter = getMemory().memory_used_size as number;
+
+    console.log("Allocation increased %d", memoryAfter - memoryBefore);
+    expect(memoryAfter - memoryBefore).toBe(0);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("memory leak promise", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, {
+      isMarshalable: true,
+      registeredObjects: [],
+      syncEnabled: false,
+    });
+
+    const getMemory = () => {
+      const handle = ctx.runtime.computeMemoryUsage();
+      const mem = ctx.dump(handle);
+      handle.dispose();
+      return mem;
+    };
+
+    arena.expose({
+      fnFromHost: () => {
+        return {
+          id: "some id",
+          data: Math.random(),
+        };
+      },
+    });
+
+    arena.evalCode(`globalThis.test = {
+      check: async () => {
+        const hostData = await fnFromHost();
+        return hostData;
+      }
+    }`);
+
+    const memoryBefore = getMemory().memory_used_size as number;
+
+    const promise = arena.evalCode<Promise<any>>("globalThis.test.check()");
+    arena.executePendingJobs();
+    const data = await promise;
+    expect(data).not.toBeNull();
+
+    for (let i = 0; i < 100; i++) {
+      const promise = arena.evalCode<Promise<any>>("globalThis.test.check()");
+      arena.executePendingJobs();
+      const data = await promise;
+      expect(data).not.toBeNull();
+    }
+
+    const memoryAfter = getMemory().memory_used_size as number;
+
+    console.log("Allocation increased %d", memoryAfter - memoryBefore);
+    expect(memoryAfter - memoryBefore).toBe(0);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+});

--- a/src/memory.test.ts
+++ b/src/memory.test.ts
@@ -46,7 +46,7 @@ describe("memory", () => {
     const memoryAfter = getMemory().memory_used_size as number;
 
     console.log("Allocation increased %d", memoryAfter - memoryBefore);
-    expect(memoryAfter - memoryBefore).toBe(0);
+    expect((memoryAfter - memoryBefore) / 1024).toBe(0);
 
     arena.dispose();
     ctx.dispose();
@@ -100,7 +100,7 @@ describe("memory", () => {
     const memoryAfter = getMemory().memory_used_size as number;
 
     console.log("Allocation increased %d", memoryAfter - memoryBefore);
-    expect(memoryAfter - memoryBefore).toBe(0);
+    expect((memoryAfter - memoryBefore) / 1024).toBe(0);
 
     arena.dispose();
     ctx.dispose();

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -12,10 +12,10 @@ export function wrap<T = any>(
   target: T,
   proxyKeySymbol: symbol,
   proxyKeySymbolHandle: QuickJSHandle,
-  syncEnabled: boolean,
   marshal: (target: any) => [QuickJSHandle, boolean],
   syncMode?: (target: T) => SyncMode | undefined,
   wrappable?: (target: unknown) => boolean,
+  syncEnabled = true,
 ): Wrapped<T> | undefined {
   // promise and date cannot be wrapped
   if (
@@ -85,10 +85,10 @@ export function wrapHandle(
   handle: QuickJSHandle,
   proxyKeySymbol: symbol,
   proxyKeySymbolHandle: QuickJSHandle,
-  syncEnabled: boolean,
   unmarshal: (handle: QuickJSHandle) => any,
   syncMode?: (target: QuickJSHandle) => SyncMode | undefined,
   wrappable?: (target: QuickJSHandle, ctx: QuickJSContext) => boolean,
+  syncEnabled = true,
 ): [Wrapped<QuickJSHandle> | undefined, boolean] {
   if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
     return [undefined, false];


### PR DESCRIPTION
Doesn't fully fix #30 but drastically reduces memory being retained in `QuickJSRuntime`.

I added 2 test cases to demonstrate this. 

Table with memory increases after 100 iterations:

|                           | Sync enabled (default) | Sync disabled | 
|---------------------------|--------|-------|
| Return object | 1320 kB | 23.8 kB | 
| Return promise | 1791 kB | 23.8 kB | 