### PR TITLE
Add 'types' in package.json 'exports'

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/quickjs-emscripten-sync.mjs",
       "require": "./dist/quickjs-emscripten-sync.umd.js"
     }


### PR DESCRIPTION
I would like to support the resolvePackageJsonExports option in tsconfig