### PR TITLE
fix(publish): add repository field required by npm provenance verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quickjs-emscripten-sync",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quickjs-emscripten-sync",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.6",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "author": "rot1024",
   "version": "1.8.2",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reearth/quickjs-emscripten-sync.git"
+  },
+  "homepage": "https://github.com/reearth/quickjs-emscripten-sync#readme",
+  "bugs": "https://github.com/reearth/quickjs-emscripten-sync/issues",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/quickjs-emscripten-sync.umd.js",


### PR DESCRIPTION
## Summary

Hot-fix for the v1.8.2 release. The first publish attempt failed at npm's provenance verification step:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/quickjs-emscripten-sync
- Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "", expected to match
"https://github.com/reearth/quickjs-emscripten-sync" from provenance
```

## Cause

npm Trusted Publishing cross-checks the package's \`repository\` field in \`package.json\` against the GitHub repo URL embedded in the OIDC-signed provenance attestation, and refuses the publish if they disagree. \`package.json\` here had **no \`repository\` field at all**, so the check failed.

## Fix

Add the standard \`repository\` / \`homepage\` / \`bugs\` trio pointing at \`reearth/quickjs-emscripten-sync\`. These also improve the package page on npmjs.com — users get a working "Repository" link rather than nothing.

## Confirmed no side effects

- \`npm view quickjs-emscripten-sync@1.8.2\` returns 404. The failed publish never uploaded a tarball.
- The \`v1.8.2\` git tag will be deleted and re-created at this PR's merge commit after it lands. The publish workflow then re-runs from scratch with the fixed \`package.json\` and \`package.json.version\` still at \`1.8.2\` so the tag-version verify still passes.
- \`actionlint\` clean; \`npm run lint\` / \`npm test --run\` (137/137) / \`npm run build\` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)