### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: quickjs-emscripten-sync
+  namespace: reearth
+  description: Provides a way to sync objects between browser and QuickJS
+  annotations:
+    github.com/project-slug: reearth/quickjs-emscripten-sync
+  links:
+  - url: https://github.com/reearth/quickjs-emscripten-sync
+    title: GitHub
+    icon: github
+  tags:
+  - typescript
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/lib


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `quickjs-emscripten-sync` (namespace `reearth`)
- **Owner:** `reearth/lib`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.