### PR TITLE
fix: dispose orphaned sibling handle when re-marshalling the same host object

### DIFF
--- a/src/remarshalleak.test.ts
+++ b/src/remarshalleak.test.ts
@@ -1,0 +1,39 @@
+import variant from "@jitl/quickjs-wasmfile-debug-sync";
+import { newQuickJSWASMModuleFromVariant } from "quickjs-emscripten";
+import { describe, expect, it } from "vitest";
+
+import { Arena } from ".";
+
+// Marshalling the same host object into the VM more than once used to leak a
+// handle: the first registration stores both a wrapped (proxy) handle and its
+// unwrapped sibling. Once the VM frees the proxy, the map entry goes stale, and
+// the lazy eviction in VMMap.get dropped the entry without disposing the
+// still-alive sibling. The debug-sync runtime aborts on dispose if any GC
+// object handle leaked, so reaching ctx.dispose() without an abort proves the
+// sibling is now released.
+async function withArena(fn: (arena: Arena) => void) {
+  const mod = await newQuickJSWASMModuleFromVariant(variant as any);
+  const ctx = mod.newContext();
+  const arena = new Arena(ctx, { isMarshalable: true });
+  fn(arena);
+  arena.dispose();
+  expect(() => ctx.dispose()).not.toThrow();
+}
+
+describe("re-marshal handle leak", () => {
+  it("does not leak when a host function returns the same object twice", async () => {
+    await withArena(arena => {
+      const shared = { k: 1 };
+      arena.expose({ get: () => shared });
+      arena.evalCode(`get(); get();`);
+    });
+  });
+
+  it("does not leak when the same object is compared across two calls", async () => {
+    await withArena(arena => {
+      const shared = { k: 1 };
+      arena.expose({ get: () => shared });
+      arena.evalCode(`get() === get();`);
+    });
+  });
+});

--- a/src/vmmap.ts
+++ b/src/vmmap.ts
@@ -121,7 +121,11 @@ export default class VMMap {
 
     if (!handle) return;
     if (!handle.alive) {
-      this.delete(key);
+      // The primary handle was freed by the VM, so this entry is stale. Dispose
+      // its sibling handle while evicting it: otherwise the sibling (e.g. the
+      // unwrapped handle registered alongside a proxy) is orphaned and leaks
+      // when the same value is marshalled again.
+      this.delete(key, true);
       return;
     }
 


### PR DESCRIPTION
## Problem

Marshalling the **same host object into the VM more than once** leaks a QuickJS handle, which aborts the debug-sync runtime on `dispose()` with:

```
Aborted(Assertion failed: list_empty(&rt->gc_obj_list), at: quickjs.c,2036,JS_FreeRuntime)
```

Minimal repro:

```js
const shared = { k: 1 };
arena.expose({ get: () => shared });
arena.evalCode(`get(); get();`); // <-- second marshal leaks
```

One `get()` is fine; the second leaks. Same for `get() === get()`.

## Root cause

The first registration stores both a **wrapped (proxy) handle** and its **unwrapped sibling** in `VMMap`. Once the VM frees the proxy, the host-side handle goes dead and the map entry becomes stale. The lazy eviction in `VMMap.get` then dropped the entry via `delete(key)` **without disposing the still-alive sibling**, orphaning it.

(Tracked this down with the debug-sync runtime: a single host-fn return registers the global graph (~420 entries) which dispose cleanly; only the re-marshalled object's sibling leaked. The leak was confirmed via `VMMap.set`/`delete` tracing showing the stale entry being `delete`d with `dispose=undefined` then re-`set`.)

## Fix

Evict the stale entry with `delete(key, true)` so the orphaned sibling is disposed. The dead primary is skipped by `delete`'s own `.alive` guard, so this only frees the leaked sibling.

## Tests

Added `src/remarshalleak.test.ts` — fails (runtime abort) without the fix, passes with it. Full suite: 163 passing, typecheck + lint clean.

## Scope note

This fixes the **handle leak** (relates to the dispose-leak family in #4 / #41). It does **not** change reference-identity behavior across the host boundary (`get() === get()` is still `false`) — that is a separate, deeper lifetime concern; `marshalByReference` remains the supported path for guaranteed identity.