### PR TITLE
fix: preserve object identity across the host boundary (#4)

### DIFF
--- a/src/edge.test.ts
+++ b/src/edge.test.ts
@@ -36,12 +36,54 @@ describe("edge cases", () => {
     expect(cb.current?.()).toBe(0);
     expect(called).toEqual(["a", "b"]);
 
+    // The host getters are still traversed on every access, so `called` grows.
+    // But `obj` keeps its identity across marshals (sync is on), so the VM holds
+    // the value snapshot from the first marshal: a later host-side mutation is
+    // not re-marshalled. Use `arena.sync(obj)` to propagate host writes (see the
+    // "getter (synced)" test below).
     obj.c = 1;
-    expect(cb.current?.()).toBe(1); // this line causes an error when context is disposed
+    expect(cb.current?.()).toBe(0);
     expect(called).toEqual(["a", "b", "a", "b"]);
 
     arena.dispose();
-    // ctx.dispose(); // reports an error
+    // Re-marshalling `obj` used to leak a handle, which aborted ctx.dispose().
+    // Now that the stale-entry handle is disposed, the context disposes cleanly.
+    expect(() => ctx.dispose()).not.toThrow();
+  });
+
+  // this test takes more than about 20s
+  test("getter (synced)", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    // A synced object propagates host-side writes to the VM, so re-reads see the
+    // updated value while still keeping a stable identity.
+    const obj = arena.sync({ c: 0 });
+    const exposed = {
+      get a() {
+        return {
+          get b() {
+            return obj;
+          },
+        };
+      },
+    };
+    const cb: { current?: () => any } = {};
+    arena.expose({
+      exposed,
+      register: (fn: () => any) => {
+        cb.current = fn;
+      },
+    });
+
+    arena.evalCode(`register(() => exposed.a.b.c);`);
+    expect(cb.current?.()).toBe(0);
+
+    obj.c = 1;
+    expect(cb.current?.()).toBe(1);
+
+    arena.dispose();
+    expect(() => ctx.dispose()).not.toThrow();
   });
 
   test(

--- a/src/identity.test.ts
+++ b/src/identity.test.ts
@@ -1,0 +1,58 @@
+import variant from "@jitl/quickjs-wasmfile-debug-sync";
+import { newQuickJSWASMModuleFromVariant } from "quickjs-emscripten";
+import { describe, expect, it } from "vitest";
+
+import { Arena } from ".";
+
+// A host function's return value is disposed by the VM once consumed. Marshalled
+// object handles are retained in the VMMap for identity while sync is on, so the
+// returned handle must be dup'd — otherwise the map entry goes stale and the same
+// value marshalled twice yields two distinct VM objects (and used to leak). These
+// tests pin the identity behaviour (issue #4).
+async function withArena(
+  options: ConstructorParameters<typeof Arena>[1],
+  fn: (arena: Arena) => void,
+) {
+  const mod = await newQuickJSWASMModuleFromVariant(variant as any);
+  const ctx = mod.newContext();
+  const arena = new Arena(ctx, options);
+  fn(arena);
+  arena.dispose();
+  expect(() => ctx.dispose()).not.toThrow();
+}
+
+describe("marshal identity", () => {
+  it("preserves identity for a VM object round-tripped through the host", async () => {
+    await withArena({ isMarshalable: true }, arena => {
+      arena.expose({ id: (x: any) => x });
+      // foo originates in the VM, is passed to the host and returned: the
+      // round-trip must yield the same object.
+      expect(arena.evalCode(`let foo = id({}); foo === id(foo)`)).toBe(true);
+    });
+  });
+
+  it("returns the same VM object when a host function returns the same object twice", async () => {
+    await withArena({ isMarshalable: true }, arena => {
+      const shared = { k: 1 };
+      arena.expose({ get: () => shared });
+      expect(arena.evalCode(`get() === get()`)).toBe(true);
+    });
+  });
+
+  it("keeps identity across retained references", async () => {
+    await withArena({ isMarshalable: true }, arena => {
+      const shared = { k: 1 };
+      arena.expose({ get: () => shared });
+      expect(arena.evalCode(`let a = get(); let b = get(); a === b`)).toBe(true);
+    });
+  });
+
+  it("does not retain identity when sync is disabled", async () => {
+    await withArena({ isMarshalable: true, syncEnabled: false }, arena => {
+      const shared = { k: 1 };
+      arena.expose({ get: () => shared });
+      // With sync off, objects are not retained, so each marshal is independent.
+      expect(arena.evalCode(`get() === get()`)).toBe(false);
+    });
+  });
+});

--- a/src/identity.test.ts
+++ b/src/identity.test.ts
@@ -1,5 +1,4 @@
-import variant from "@jitl/quickjs-wasmfile-debug-sync";
-import { newQuickJSWASMModuleFromVariant } from "quickjs-emscripten";
+import { getQuickJS } from "quickjs-emscripten";
 import { describe, expect, it } from "vitest";
 
 import { Arena } from ".";
@@ -7,18 +6,18 @@ import { Arena } from ".";
 // A host function's return value is disposed by the VM once consumed. Marshalled
 // object handles are retained in the VMMap for identity while sync is on, so the
 // returned handle must be dup'd — otherwise the map entry goes stale and the same
-// value marshalled twice yields two distinct VM objects (and used to leak). These
-// tests pin the identity behaviour (issue #4).
+// value marshalled twice yields two distinct VM objects. These tests pin the
+// identity behaviour (issue #4); the no-leak side is covered by
+// remarshalleak.test.ts under the debug-sync runtime.
 async function withArena(
   options: ConstructorParameters<typeof Arena>[1],
   fn: (arena: Arena) => void,
 ) {
-  const mod = await newQuickJSWASMModuleFromVariant(variant as any);
-  const ctx = mod.newContext();
+  const ctx = (await getQuickJS()).newContext();
   const arena = new Arena(ctx, options);
   fn(arena);
   arena.dispose();
-  expect(() => ctx.dispose()).not.toThrow();
+  ctx.dispose();
 }
 
 describe("marshal identity", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -490,6 +490,7 @@ export class Arena {
       registerTransient: this._registerTransient,
       disposeTransient: this._disposeTransient,
       preApply: this._marshalPreApply,
+      prepareReturn: this._prepareMarshalReturn,
       custom: this._options?.customMarshaller,
     });
 
@@ -499,6 +500,17 @@ export class Arena {
 
     const syncEnabled = this._options?.syncEnabled ?? true;
     return [handle, !syncEnabled || !this._map.hasHandle(handle)];
+  };
+
+  _prepareMarshalReturn = (h: QuickJSHandle): QuickJSHandle => {
+    // A host function's return value is disposed by the VM once it is consumed.
+    // When sync is on, the VMMap retains object handles for identity, so the
+    // handle we hand back is the one the map owns: returning it directly would
+    // let the VM dispose the map's copy, leaving a stale entry that breaks
+    // `x === fn()` identity across calls. Hand the VM a dup instead and keep
+    // ours alive. With sync off, handles are not retained, so this is a no-op.
+    const syncEnabled = this._options?.syncEnabled ?? true;
+    return syncEnabled && h.alive && this._map.hasHandle(h) ? h.dup() : h;
   };
 
   _preUnmarshal = (t: any, h: QuickJSHandle): Wrapped<any> => {

--- a/src/marshal/function.ts
+++ b/src/marshal/function.ts
@@ -13,6 +13,7 @@ export default function marshalFunction(
   preMarshal: (target: unknown, handle: QuickJSHandle) => QuickJSHandle | undefined,
   preApply?: (target: (...args: any[]) => any, thisArg: unknown, args: unknown[]) => any,
   disposeTransient: (handle: QuickJSHandle) => void = () => {},
+  prepareReturn: (handle: QuickJSHandle) => QuickJSHandle = h => h,
 ): QuickJSHandle | undefined {
   if (typeof target !== "function") return;
 
@@ -33,7 +34,16 @@ export default function marshalFunction(
         return this;
       }
 
-      return marshal(preApply ? preApply(target as (...args: any[]) => any, that, args) : (target as (...args: any[]) => any).apply(that, args));
+      // The VM disposes whatever we return here. `prepareReturn` dups the
+      // handle when the VMMap retains it, so the map keeps a live copy and
+      // identity (`x === fn()` across calls) survives instead of going stale.
+      return prepareReturn(
+        marshal(
+          preApply
+            ? preApply(target as (...args: any[]) => any, that, args)
+            : (target as (...args: any[]) => any).apply(that, args),
+        ),
+      );
     })
     .consume(handle2 =>
       // fucntions created by vm.newFunction are not callable as a class constrcutor

--- a/src/marshal/index.ts
+++ b/src/marshal/index.ts
@@ -28,6 +28,11 @@ export type Options = {
     mode: true | "json" | undefined,
   ) => QuickJSHandle | undefined;
   preApply?: (target: (...args: any[]) => any, thisArg: unknown, args: unknown[]) => any;
+  // Adjust ownership of a handle that is about to be handed to the VM as a host
+  // function's return value. The VM disposes whatever it receives, so a handle
+  // the VMMap retains (for identity, while sync is on) must be dup'd here or its
+  // map entry goes stale. Defaults to identity (no-op).
+  prepareReturn?: (handle: QuickJSHandle) => QuickJSHandle;
   custom?: Iterable<(obj: unknown, ctx: QuickJSContext) => QuickJSHandle | undefined>;
 };
 
@@ -73,7 +78,16 @@ export function marshal(target: unknown, options: Options): QuickJSHandle {
   return (
     marshalCustom(ctx, target, pre2, [...defaultCustom, ...(options.custom ?? [])]) ??
     marshalPromise(ctx, target, marshal2, pre2) ??
-    marshalFunction(ctx, target, marshal2, unmarshal, pre2, options.preApply, disposeTransient) ??
+    marshalFunction(
+      ctx,
+      target,
+      marshal2,
+      unmarshal,
+      pre2,
+      options.preApply,
+      disposeTransient,
+      options.prepareReturn,
+    ) ??
     marshalMapSet(ctx, target, marshal2, pre2, disposeTransient) ??
     marshalObject(ctx, target, marshal2, pre2, disposeTransient) ??
     ctx.undefined

--- a/src/remarshalleak.test.ts
+++ b/src/remarshalleak.test.ts
@@ -21,19 +21,30 @@ async function withArena(fn: (arena: Arena) => void) {
 }
 
 describe("re-marshal handle leak", () => {
-  it("does not leak when a host function returns the same object twice", async () => {
-    await withArena(arena => {
-      const shared = { k: 1 };
-      arena.expose({ get: () => shared });
-      arena.evalCode(`get(); get();`);
-    });
-  });
+  // Calling an exposed function from inside the VM marshals the whole global
+  // graph on each call, which is slow under the debug-sync runtime + coverage,
+  // so these get a generous timeout (cf. the "many newFunction" edge test).
+  it(
+    "does not leak when a host function returns the same object twice",
+    async () => {
+      await withArena(arena => {
+        const shared = { k: 1 };
+        arena.expose({ get: () => shared });
+        arena.evalCode(`get(); get();`);
+      });
+    },
+    90000,
+  );
 
-  it("does not leak when the same object is compared across two calls", async () => {
-    await withArena(arena => {
-      const shared = { k: 1 };
-      arena.expose({ get: () => shared });
-      arena.evalCode(`get() === get();`);
-    });
-  });
+  it(
+    "does not leak when the same object is compared across two calls",
+    async () => {
+      await withArena(arena => {
+        const shared = { k: 1 };
+        arena.expose({ get: () => shared });
+        arena.evalCode(`get() === get();`);
+      });
+    },
+    90000,
+  );
 });


### PR DESCRIPTION
Closes part of #4.

## Problem

Reference identity was not preserved across the host boundary in the default (sync-on) mode:

```js
arena.expose({ id: (x) => x });
arena.evalCode(`let foo = id({}); foo === id(foo)`); // was false

const shared = { k: 1 };
arena.expose({ get: () => shared });
arena.evalCode(`get() === get()`); // was false
```

## Root cause

A host function's return value is disposed by the VM once consumed. The `VMMap` retains marshalled object handles for identity while sync is on — but the handle returned to the VM **was the map's own handle**, so the VM disposed it and the entry went stale. Marshalling the same value again then missed the map, created a fresh VM object (breaking `===`) and orphaned the sibling handle (the leak fixed in #83 was the same root mechanism surfacing as a dispose-time abort).

## Fix

Hand the VM a `dup()` of the handle when the `VMMap` retains it (`prepareReturn`), keeping the map's copy alive. `find` then returns a live handle on the next marshal, so identity holds.

- Scoped to host **function returns** (the consume point that disposed the map's handle).
- Gated on `syncEnabled`: with `syncEnabled: false` nothing is retained, so no dup — behaviour unchanged.

## Behavioural note (decided with maintainer)

Identity retention means a host object marshalled once is **identity-cached**: a later host-side mutation is *not* picked up by re-marshalling. `arena.sync(obj)` remains the supported way to propagate host writes to the VM. The `edge.test.ts > getter` test documented the old re-marshal-each-time behaviour (which was also what leaked); it's updated to the new semantics, plus a new `getter (synced)` test shows live tracking via `arena.sync`. Its `ctx.dispose()` is un-commented now that the leak is gone.

## Tests

New `src/identity.test.ts` pins identity (round-trip, repeated returns, retained refs, and the sync-off negative case). Full suite: 168 passing, typecheck + lint clean.