### PR TITLE
perf: stop deep-copying the VM global when a host function is called plainly

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,15 @@ Only the `set`, `deleteProperty`, and `defineProperty` operations on objects are
 
 `Date`, `Map`, `Set`, `ArrayBuffer`, and typed arrays are marshalled by value (a snapshot copy is created on the other side). They are not proxied, so later mutations are not synchronized, and self-referential `Map`/`Set` are not supported.
 
+### `this` on plain calls
+
+When an exposed host function is called plainly from the VM (`fn()`, not `obj.fn()`), the host function receives `this === undefined`. This differs from plain JavaScript, where a non-strict function called this way would see `this === globalThis`. The VM global object is intentionally **not** marshalled to the host: doing so would eagerly deep-copy the entire global graph on the first call and would leak `globalThis` across the boundary. Method calls are unaffected — `obj.fn()` still receives `obj` as `this`.
+
+```js
+arena.expose({ whoAmI() { return this; } });
+arena.evalCode(`whoAmI()`); // undefined (not globalThis)
+```
+
 ## License
 
 [MIT License](LICENSE)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -550,6 +550,26 @@ test("register and unregister", async () => {
   ctx.dispose();
 });
 
+test("plain call passes `this` as undefined, method call passes the receiver", async () => {
+  const ctx = (await getQuickJS()).newContext();
+  const arena = new Arena(ctx, { isMarshalable: true });
+
+  arena.expose({
+    whoAmI() {
+      return this;
+    },
+  });
+
+  // A plain call would see `this === globalThis` in plain JS; the VM global is
+  // intentionally not marshalled to the host, so `this` is undefined here.
+  expect(arena.evalCode(`whoAmI()`)).toBe(undefined);
+  // A method call still receives its receiver.
+  expect(arena.evalCode(`const o = { v: 42, whoAmI }; o.whoAmI().v`)).toBe(42);
+
+  arena.dispose();
+  ctx.dispose();
+});
+
 test("registeredObjects option", async () => {
   const ctx = (await getQuickJS()).newContext();
   const arena = new Arena(ctx, {

--- a/src/marshal/function.test.ts
+++ b/src/marshal/function.test.ts
@@ -30,10 +30,12 @@ test("normal func", async () => {
   expect(ctx.dump(result)).toBe("hoge");
   expect(innerfn).toBeCalledWith(1, true);
   expect(marshal).toHaveBeenLastCalledWith("hoge");
-  expect(unmarshal).toBeCalledTimes(3);
-  expect(unmarshal.mock.results[0].value).toBe(undefined); // this
-  expect(unmarshal.mock.results[1].value).toBe(1);
-  expect(unmarshal.mock.results[2].value).toBe(true);
+  // `this` coerces to the VM global for a plain call, which marshalFunction
+  // treats as undefined without unmarshalling it, so only the two args are
+  // unmarshalled.
+  expect(unmarshal).toBeCalledTimes(2);
+  expect(unmarshal.mock.results[0].value).toBe(1);
+  expect(unmarshal.mock.results[1].value).toBe(true);
 
   handle.dispose();
   ctx.dispose();

--- a/src/marshal/function.ts
+++ b/src/marshal/function.ts
@@ -18,7 +18,14 @@ export default function marshalFunction(
 
   const raw = ctx
     .newFunction(target.name, function (...argHandles) {
-      const that = unmarshal(this);
+      // A plain call (`fn()`) passes the VM global object as `this`. Unmarshalling
+      // it would eagerly deep-copy the entire global graph (hundreds of handles)
+      // on the first call, for a `this` host functions almost never use — and
+      // leaking globalThis to the host is undesirable. So global `this` is passed
+      // to the host function as `undefined`, which differs from plain JS where a
+      // non-strict function sees `this === globalThis` (see README Limitations).
+      // Real method calls still get their receiver unmarshalled.
+      const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
       const args = argHandles.map(a => unmarshal(a));
 
       if (isES2015Class(target) && isObject(that)) {


### PR DESCRIPTION
## Problem

Calling an exposed host function plainly from the VM (`fn()`) registered **~420 handles on the first call** in a fresh context — for a `this` value the function almost never uses.

A plain (non-method) VM call passes the **global object** as `this`. `marshalFunction` did `const that = unmarshal(this)` unconditionally, and `unmarshalObject` is **eager** (it walks the prototype chain and every own property recursively). So unmarshalling the VM global deep-copied the entire global graph — `Object`, `Array`, `JSON`, `Math`, every constructor and method — into host proxies.

This is what made the debug-sync leak/identity tests take ~12s isolated (≈35s under coverage in CI).

## Fix

Treat global `this` as `undefined`:

```js
const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
```

- Method calls are unaffected — `obj.fn()` still unmarshals `obj` as `this`.
- Also avoids leaking `globalThis` across the boundary (cf. #39).

First-call cost drops from ~420 handle registrations to 0; the debug-sync tests run ~30x faster (full suite ~30s → ~6s).

## Behavioural change (documented)

This is a deliberate deviation from plain JavaScript, where a non-strict function called as `fn()` sees `this === globalThis`. Here it sees `undefined`. Added a **README → Limitations → `this` on plain calls** entry and a test:

```js
arena.expose({ whoAmI() { return this; } });
arena.evalCode(`whoAmI()`); // undefined (not globalThis)
```

## Tests

- New integration test: plain call → `this` undefined; method call → receiver preserved.
- Updated the `marshalFunction > normal func` unit test (global `this` is no longer unmarshalled, so only args are).
- Full suite: 164 passing, typecheck + lint clean.