### PR TITLE
ci: commit package-lock.json in the release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,9 @@ jobs:
         run: |
           BRANCH_NAME="release/v${{ steps.bump_version.outputs.new_version }}"
           git checkout -b "$BRANCH_NAME"
-          git add package.json CHANGELOG.md
+          # `npm version` above bumps package-lock.json too, so commit it as well
+          # to keep the lockfile in sync with package.json.
+          git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore: release v${{ steps.bump_version.outputs.new_version }}"
           git push origin "$BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The release workflow runs `npm version <type> --no-git-tag-version`, which bumps **both** `package.json` and `package-lock.json`. But the "Create release branch and commit" step only staged `package.json` and `CHANGELOG.md`, so the lockfile version was never committed.

As a result the lockfile's `version` field drifted — it sat at `1.8.4` through the v1.9.0 and v1.9.1 releases while `package.json` moved on.

This is harmless for publishing (the lockfile isn't published and `npm ci` doesn't fail on the root version field), but it's a hygiene issue: a fresh `npm install` produces a spurious lockfile diff.

## Fix

Stage `package-lock.json` in the release commit too.

The current release PR (v1.10.0, #86) has already had its lockfile synced manually; this keeps every future release in sync automatically.