### PR TITLE
fix: detect class constructors behind the host proxy wrapper (#92)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,6 +73,70 @@ describe("readme", () => {
   });
 });
 
+describe("class constructors (#92)", () => {
+  test("new on an exposed class inside the VM", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      hoge = "";
+
+      constructor() {
+        this.hoge = "foo";
+      }
+    }
+    arena.expose({ Cls });
+
+    const instance = arena.evalCode(`new Cls()`) as { hoge: string };
+    expect(instance.hoge).toBe("foo");
+    expect(arena.evalCode(`new Cls() instanceof Cls`)).toBe(true);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("constructor arguments reach the host", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      value: number;
+
+      constructor(a: number, b: number) {
+        this.value = a + b;
+      }
+    }
+    arena.expose({ Cls });
+
+    const instance = arena.evalCode(`new Cls(2, 3)`) as { value: number };
+    expect(instance.value).toBe(5);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("new on a synced class inside the VM", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      hoge = "";
+
+      constructor(v = "foo") {
+        this.hoge = v;
+      }
+    }
+    arena.expose({ Cls: arena.sync(Cls) });
+
+    const instance = arena.evalCode(`new Cls("bar")`) as { hoge: string };
+    expect(instance.hoge).toBe("bar");
+    expect(arena.evalCode(`new Cls() instanceof Cls`)).toBe(true);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+});
+
 describe("evalCode", () => {
   test("simple object and function", async () => {
     const ctx = (await getQuickJS()).newContext();

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,6 +491,7 @@ export class Arena {
       disposeTransient: this._disposeTransient,
       preApply: this._marshalPreApply,
       prepareReturn: this._prepareMarshalReturn,
+      unwrap: t => this._unwrap(t),
       custom: this._options?.customMarshaller,
     });
 

--- a/src/marshal/function.ts
+++ b/src/marshal/function.ts
@@ -14,8 +14,15 @@ export default function marshalFunction(
   preApply?: (target: (...args: any[]) => any, thisArg: unknown, args: unknown[]) => any,
   disposeTransient: (handle: QuickJSHandle) => void = () => {},
   prepareReturn: (handle: QuickJSHandle) => QuickJSHandle = h => h,
+  unwrap: (target: unknown) => unknown = t => t,
 ): QuickJSHandle | undefined {
   if (typeof target !== "function") return;
+
+  // `target` may be a host-side proxy wrapper; unwrap it before the class check,
+  // because Function.prototype.toString on a callable proxy never matches /^class/.
+  // Computed once here rather than per call to avoid the toString + regex on every
+  // VM→host invocation.
+  const isClass = isES2015Class(unwrap(target));
 
   const raw = ctx
     .newFunction(target.name, function (...argHandles) {
@@ -29,9 +36,9 @@ export default function marshalFunction(
       const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
       const args = argHandles.map(a => unmarshal(a));
 
-      if (isES2015Class(target) && isObject(that)) {
+      if (isClass && isObject(that)) {
         // Class constructors cannot be invoked without new expression, and new.target is not changed
-        const result = new target(...args);
+        const result = new (target as new (...args: any[]) => any)(...args);
         Object.entries(result).forEach(([key, value]) => {
           const valueHandle = marshal(value);
           ctx.setProp(this, key, valueHandle);

--- a/src/marshal/index.ts
+++ b/src/marshal/index.ts
@@ -33,6 +33,9 @@ export type Options = {
   // the VMMap retains (for identity, while sync is on) must be dup'd here or its
   // map entry goes stale. Defaults to identity (no-op).
   prepareReturn?: (handle: QuickJSHandle) => QuickJSHandle;
+  // Strip a host-side proxy wrapper from a target. Used to detect a wrapped class
+  // constructor, which would otherwise be hidden behind the proxy. Defaults to identity.
+  unwrap?: (target: unknown) => unknown;
   custom?: Iterable<(obj: unknown, ctx: QuickJSContext) => QuickJSHandle | undefined>;
 };
 
@@ -87,6 +90,7 @@ export function marshal(target: unknown, options: Options): QuickJSHandle {
       options.preApply,
       disposeTransient,
       options.prepareReturn,
+      options.unwrap,
     ) ??
     marshalMapSet(ctx, target, marshal2, pre2, disposeTransient) ??
     marshalObject(ctx, target, marshal2, pre2, disposeTransient) ??


### PR DESCRIPTION
## Summary

Fixes #92: exposing a host ES2015 class and calling `new Cls()` inside the VM threw `TypeError: Class constructor Cls cannot be invoked without 'new'`.

**Root cause**: `Arena._marshal` wraps the class in a host-side Proxy before `marshalFunction` runs its class check. `Function.prototype.toString` on a callable Proxy returns `"function () { [native code] }"` per the ES spec, so `isES2015Class` never matched `/^class\s/` and the trampoline fell through to `target.apply(...)`, which throws for class constructors.

**Fix**: thread the Arena's `unwrap` into marshal options and compute `isES2015Class(unwrap(target))` once outside the `ctx.newFunction` trampoline. This also removes a per-invocation `Function.prototype.toString` + regex from the VM→host hot path.

**Tests**: added regression tests that construct instances INSIDE the VM (the existing readme test only constructed on the host, which is why this went unnoticed).

Fixes #92