### PR TITLE
feat: accept filename and eval options in evalCode/evalModule

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -318,6 +318,36 @@ describe("evalCode", () => {
     arena.dispose();
     ctx.dispose();
   });
+
+  test("options are forwarded (strict mode)", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    // Assigning to an undeclared variable succeeds in sloppy mode...
+    expect(arena.evalCode("x = 1")).toBe(1);
+    // ...but throws a ReferenceError in strict mode.
+    expect(() => arena.evalCode("y = 1", undefined, { strict: true })).toThrow(ReferenceError);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("filename appears in error stacks", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    try {
+      arena.evalCode(`throw new Error("boom")`, "my-special-file.js");
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect((e as Error).message).toBe("boom");
+      expect((e as Error).stack).toContain("my-special-file.js");
+    }
+
+    arena.dispose();
+    ctx.dispose();
+  });
 });
 
 describe("expose without sync", () => {
@@ -900,6 +930,30 @@ describe("evalModule", () => {
     arena.dispose();
     ctx.dispose();
   });
+
+  test("user options are merged and type is forced to module", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    // `strict` is passed through, and a user-supplied `type` is overridden with
+    // "module" so `export` still works and the exports are returned.
+    const exports = arena.evalModule(
+      `
+      export const value = 42;
+      export function greet(name) {
+        return "Hi, " + name;
+      }
+    `,
+      "with-options.js",
+      { strict: true, type: "global" },
+    );
+
+    expect(exports.value).toBe(42);
+    expect(exports.greet("World")).toBe("Hi, World");
+
+    arena.dispose();
+    ctx.dispose();
+  });
 });
 
 describe("memory management", () => {
@@ -1095,6 +1149,27 @@ describe("memory management", () => {
         }
       `);
     }).toThrow();
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("setInterruptHandler interrupts infinite loops", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    // Interrupt after the handler has been called a number of times.
+    let calls = 0;
+    arena.setInterruptHandler(() => ++calls > 1000);
+
+    expect(() => {
+      arena.evalCode(`while (true) {}`);
+    }).toThrow();
+    expect(calls).toBeGreaterThan(1000);
+
+    // After removing the handler, normal evaluation works again.
+    arena.removeInterruptHandler();
+    expect(arena.evalCode(`1 + 2`)).toBe(3);
 
     arena.dispose();
     ctx.dispose();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,6 +73,70 @@ describe("readme", () => {
   });
 });
 
+describe("class constructors (#92)", () => {
+  test("new on an exposed class inside the VM", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      hoge = "";
+
+      constructor() {
+        this.hoge = "foo";
+      }
+    }
+    arena.expose({ Cls });
+
+    const instance = arena.evalCode(`new Cls()`) as { hoge: string };
+    expect(instance.hoge).toBe("foo");
+    expect(arena.evalCode(`new Cls() instanceof Cls`)).toBe(true);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("constructor arguments reach the host", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      value: number;
+
+      constructor(a: number, b: number) {
+        this.value = a + b;
+      }
+    }
+    arena.expose({ Cls });
+
+    const instance = arena.evalCode(`new Cls(2, 3)`) as { value: number };
+    expect(instance.value).toBe(5);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("new on a synced class inside the VM", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      hoge = "";
+
+      constructor(v = "foo") {
+        this.hoge = v;
+      }
+    }
+    arena.expose({ Cls: arena.sync(Cls) });
+
+    const instance = arena.evalCode(`new Cls("bar")`) as { hoge: string };
+    expect(instance.hoge).toBe("bar");
+    expect(arena.evalCode(`new Cls() instanceof Cls`)).toBe(true);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+});
+
 describe("evalCode", () => {
   test("simple object and function", async () => {
     const ctx = (await getQuickJS()).newContext();

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import type {
   SuccessOrFail,
   VmCallResult,
   Intrinsics,
+  ContextEvalOptions,
+  InterruptHandler,
 } from "quickjs-emscripten";
 
 import { wrapContext, QuickJSContextEx } from "./contextex";
@@ -44,7 +46,7 @@ export {
   consumeAll,
 };
 
-export type { Intrinsics };
+export type { Intrinsics, ContextEvalOptions, InterruptHandler };
 
 export type Options = {
   /** A callback that returns a boolean value that determines whether an object is marshalled or not. If false, no marshaling will be done and undefined will be passed to the QuickJS VM, otherwise marshaling will be done. By default, all objects will be marshalled. */
@@ -148,9 +150,15 @@ export class Arena {
 
   /**
    * Evaluate JS code in the VM and get the result as an object on the host side. It also converts and re-throws error objects when an error is thrown during evaluation.
+   *
+   * @param code - The JS code to evaluate
+   * @param filename - Optional filename used in error stacks and for debugging
+   * @param options - Optional eval options forwarded to quickjs-emscripten's
+   *   `evalCode`, either an `EvalFlags` bitmask (`number`) or a
+   *   {@link ContextEvalOptions} object (e.g. `{ strict: true }`)
    */
-  evalCode<T = any>(code: string): T {
-    const handle = this.context.evalCode(code);
+  evalCode<T = any>(code: string, filename?: string, options?: number | ContextEvalOptions): T {
+    const handle = this.context.evalCode(code, filename, options);
     return this._unwrapResultAndUnmarshal(handle);
   }
 
@@ -161,6 +169,10 @@ export class Arena {
    *
    * @param code - The ES module code to evaluate
    * @param filename - Optional filename for debugging purposes (default: "module.js")
+   * @param options - Optional {@link ContextEvalOptions}. `type` is always forced
+   *   to `"module"`, so any `type` in `options` is overridden. A numeric
+   *   `EvalFlags` bitmask cannot be merged with the forced module type and is
+   *   therefore not supported here; if a number is passed it is ignored.
    * @returns The module's exports object, or a Promise resolving to exports if using top-level await
    *
    * @example
@@ -186,8 +198,15 @@ export class Arena {
    * console.log(exports.data); // 123
    * ```
    */
-  evalModule<T = any>(code: string, filename = "module.js"): T | Promise<T> {
-    const handle = this.context.evalCode(code, filename, { type: "module" });
+  evalModule<T = any>(
+    code: string,
+    filename = "module.js",
+    options?: number | ContextEvalOptions,
+  ): T | Promise<T> {
+    const handle = this.context.evalCode(code, filename, {
+      ...(typeof options === "number" ? {} : options),
+      type: "module",
+    });
     return this._unwrapResultAndUnmarshal(handle);
   }
 
@@ -248,6 +267,45 @@ export class Arena {
    */
   setMaxStackSize(stackSize: number): void {
     this.context.runtime.setMaxStackSize(stackSize);
+  }
+
+  /**
+   * Set a callback which is regularly called by the QuickJS engine when it is
+   * executing code. This callback can be used to implement an execution
+   * timeout: return `true` from the handler to interrupt the running code.
+   *
+   * This is useful for preventing runaway CPU usage (e.g. infinite loops) in
+   * untrusted code.
+   *
+   * @param cb - The interrupt handler. Return `true` to interrupt execution.
+   *
+   * @example
+   * ```js
+   * // Interrupt evaluation after 1 second
+   * const deadline = Date.now() + 1000;
+   * arena.setInterruptHandler(() => Date.now() > deadline);
+   *
+   * try {
+   *   arena.evalCode(`while (true) {}`);
+   * } catch (e) {
+   *   console.log("Execution interrupted");
+   * }
+   * ```
+   */
+  setInterruptHandler(cb: InterruptHandler): void {
+    this.context.runtime.setInterruptHandler(cb);
+  }
+
+  /**
+   * Remove the interrupt handler previously set with `setInterruptHandler`.
+   *
+   * @example
+   * ```js
+   * arena.removeInterruptHandler();
+   * ```
+   */
+  removeInterruptHandler(): void {
+    this.context.runtime.removeInterruptHandler();
   }
 
   /**
@@ -661,9 +719,19 @@ export class AsyncArena extends Arena {
    * Evaluate JS code asynchronously in the VM and get the result on the host
    * side. Like `evalCode`, it converts and re-throws errors thrown during
    * evaluation. Use this when the code awaits host-provided promises.
+   *
+   * @param code - The JS code to evaluate
+   * @param filename - Optional filename used in error stacks and for debugging
+   * @param options - Optional eval options forwarded to quickjs-emscripten's
+   *   `evalCodeAsync`, either an `EvalFlags` bitmask (`number`) or a
+   *   {@link ContextEvalOptions} object (e.g. `{ strict: true }`)
    */
-  async evalCodeAsync<T = any>(code: string, filename?: string): Promise<T> {
-    const result = await this.asyncContext.evalCodeAsync(code, filename);
+  async evalCodeAsync<T = any>(
+    code: string,
+    filename?: string,
+    options?: number | ContextEvalOptions,
+  ): Promise<T> {
+    const result = await this.asyncContext.evalCodeAsync(code, filename, options);
     return this._unwrapResultAndUnmarshal(result);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,6 +491,7 @@ export class Arena {
       disposeTransient: this._disposeTransient,
       preApply: this._marshalPreApply,
       prepareReturn: this._prepareMarshalReturn,
+      unwrap: t => this._unwrap(t),
       custom: this._options?.customMarshaller,
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { defaultRegisteredObjects } from "./default";
 import marshal from "./marshal";
 import unmarshal from "./unmarshal";
 import unmarshalHostRef from "./unmarshal/hostref";
+import unmarshalPrimitive from "./unmarshal/primitive";
 import { complexity, isES2015Class, isObject, walkObject } from "./util";
 import VMMap from "./vmmap";
 import {
@@ -523,6 +524,14 @@ export class Arena {
   };
 
   _unmarshal = (handle: QuickJSHandle): any => {
+    // Primitives (undefined/number/string/boolean/bigint/null) are resolved by a
+    // cheap host-side `ctx.typeof`, skipping the `_registeredMap` VM lookup,
+    // HostRef resolution, and `_wrapHandle`. The VMMap only ever keys objects and
+    // symbols, so a primitive handle can never match `getByHandle`; symbols fall
+    // through `unmarshalPrimitive` and still reach the lookup below.
+    const [primitive, ok] = unmarshalPrimitive(this.context, handle);
+    if (ok) return primitive;
+
     const registered = this._registeredMap.getByHandle(handle);
     if (typeof registered !== "undefined") {
       return registered;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
   enableFnCache,
   disposeFnCache,
 } from "./vmutil";
-import { wrap, wrapHandle, unwrap, unwrapHandle, Wrapped } from "./wrapper";
+import { wrap, createWrapHandle, unwrap, unwrapHandle, Wrapped, WrapHandle } from "./wrapper";
 
 export {
   VMMap,
@@ -92,6 +92,7 @@ export class Arena {
   _temporalSync = new Set<any>();
   _symbol = Symbol();
   _symbolHandle: QuickJSHandle;
+  _wrapHandleImpl: WrapHandle;
   _options?: Options;
 
   /** Constructs a new Arena instance. It requires a quickjs-emscripten context initialized with `quickjs.newContext()`. */
@@ -108,6 +109,17 @@ export class Arena {
     enableFnCache(this.context);
     this._options = options;
     this._symbolHandle = ctx.unwrapResult(ctx.evalCode(`Symbol()`));
+    // One proxyFuncs handle shared by every wrapped handle for the Arena's
+    // lifetime, instead of allocating a fresh VM function per wrap.
+    this._wrapHandleImpl = createWrapHandle(
+      this.context,
+      this._symbol,
+      this._symbolHandle,
+      this._unmarshal,
+      this._syncMode,
+      this._options?.isHandleWrappable,
+      this._options?.syncEnabled ?? true,
+    );
     this._map = new VMMap(ctx);
     this._registeredMap = new VMMap(ctx);
     this.registerAll(options?.registeredObjects ?? defaultRegisteredObjects);
@@ -123,6 +135,7 @@ export class Arena {
     this._transientHandles.clear();
     this._map.dispose();
     this._registeredMap.dispose();
+    this._wrapHandleImpl.dispose();
     this._symbolHandle.dispose();
     disposeFnCache(this.context);
     this.context.disposeEx?.();
@@ -622,16 +635,7 @@ export class Arena {
   };
 
   _wrapHandle(handle: QuickJSHandle): [Wrapped<QuickJSHandle> | undefined, boolean] {
-    return wrapHandle(
-      this.context,
-      handle,
-      this._symbol,
-      this._symbolHandle,
-      this._unmarshal,
-      this._syncMode,
-      this._options?.isHandleWrappable,
-      this._options?.syncEnabled ?? true,
-    );
+    return this._wrapHandleImpl.wrapHandle(handle);
   }
 
   _unwrapHandle(target: QuickJSHandle): [QuickJSHandle, boolean] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,7 +501,11 @@ export class Arena {
     this._transientHandles.delete(handle);
 
     const syncEnabled = this._options?.syncEnabled ?? true;
-    return [handle, !syncEnabled || !this._map.hasHandle(handle)];
+    // A non-object (primitive) handle is never retained in `_map` (registered
+    // primitives already returned above via `_registeredMap`), so skip the
+    // `hasHandle` VM roundtrip and mark it disposable directly.
+    if (!syncEnabled || !isObject(target)) return [handle, true];
+    return [handle, !this._map.hasHandle(handle)];
   };
 
   _prepareMarshalReturn = (h: QuickJSHandle): QuickJSHandle => {
@@ -512,7 +516,12 @@ export class Arena {
     // `x === fn()` identity across calls. Hand the VM a dup instead and keep
     // ours alive. With sync off, handles are not retained, so this is a no-op.
     const syncEnabled = this._options?.syncEnabled ?? true;
-    return syncEnabled && h.alive && this._map.hasHandle(h) ? h.dup() : h;
+    // Only object handles are retained in `_map`; a primitive return can never
+    // be in the map, so `isHandleObject` (a cheap typeof) skips the `hasHandle`
+    // VM roundtrip for primitive returns from host functions.
+    return syncEnabled && h.alive && isHandleObject(this.context, h) && this._map.hasHandle(h)
+      ? h.dup()
+      : h;
   };
 
   _preUnmarshal = (t: any, h: QuickJSHandle): Wrapped<any> => {

--- a/src/marshal/function.ts
+++ b/src/marshal/function.ts
@@ -14,8 +14,15 @@ export default function marshalFunction(
   preApply?: (target: (...args: any[]) => any, thisArg: unknown, args: unknown[]) => any,
   disposeTransient: (handle: QuickJSHandle) => void = () => {},
   prepareReturn: (handle: QuickJSHandle) => QuickJSHandle = h => h,
+  unwrap: (target: unknown) => unknown = t => t,
 ): QuickJSHandle | undefined {
   if (typeof target !== "function") return;
+
+  // `target` may be a host-side proxy wrapper; unwrap it before the class check,
+  // because Function.prototype.toString on a callable proxy never matches /^class/.
+  // Computed once here rather than per call to avoid the toString + regex on every
+  // VM→host invocation.
+  const isClass = isES2015Class(unwrap(target));
 
   const raw = ctx
     .newFunction(target.name, function (...argHandles) {
@@ -29,9 +36,9 @@ export default function marshalFunction(
       const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
       const args = argHandles.map(a => unmarshal(a));
 
-      if (isES2015Class(target) && isObject(that)) {
+      if (isClass && isObject(that)) {
         // Class constructors cannot be invoked without new expression, and new.target is not changed
-        const result = new target(...args);
+        const result = new (target as new (...args: any[]) => any)(...args);
         Object.entries(result).forEach(([key, value]) => {
           const valueHandle = marshal(value);
           ctx.setProp(this, key, valueHandle);

--- a/src/marshal/index.ts
+++ b/src/marshal/index.ts
@@ -33,6 +33,9 @@ export type Options = {
   // the VMMap retains (for identity, while sync is on) must be dup'd here or its
   // map entry goes stale. Defaults to identity (no-op).
   prepareReturn?: (handle: QuickJSHandle) => QuickJSHandle;
+  // Strip a host-side proxy wrapper from a target. Used to detect a wrapped class
+  // constructor, which would otherwise be hidden behind the proxy. Defaults to identity.
+  unwrap?: (target: unknown) => unknown;
   custom?: Iterable<(obj: unknown, ctx: QuickJSContext) => QuickJSHandle | undefined>;
 };
 
@@ -87,6 +90,7 @@ export function marshal(target: unknown, options: Options): QuickJSHandle {
       options.preApply,
       disposeTransient,
       options.prepareReturn,
+      options.unwrap,
     ) ??
     marshalMapSet(ctx, target, marshal2, pre2, disposeTransient) ??
     marshalObject(ctx, target, marshal2, pre2, disposeTransient) ??

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,7 +1,7 @@
 import type { QuickJSHandle, QuickJSContext } from "quickjs-emscripten";
 
 import { isObject } from "./util";
-import { call, consume, isHandleObject, mayConsumeAll } from "./vmutil";
+import { call, isHandleObject, mayConsumeAll } from "./vmutil";
 
 export type SyncMode = "both" | "vm" | "host";
 
@@ -113,23 +113,34 @@ export function wrap<T = any>(
   return rec;
 }
 
-export function wrapHandle(
+export type WrapHandle = {
+  /** Wrap a VM handle with the shared proxyFuncs, like the old `wrapHandle`. */
+  wrapHandle: (handle: QuickJSHandle) => [Wrapped<QuickJSHandle> | undefined, boolean];
+  /** Dispose the shared proxyFuncs handle. Call exactly once, at Arena dispose. */
+  dispose: () => void;
+};
+
+/**
+ * Build a `wrapHandle` function that shares ONE `proxyFuncs` handle across every
+ * handle it wraps, instead of allocating a fresh VM function per wrapped object.
+ *
+ * The callbacks inside proxyFuncs (getSyncMode/setter/deleter/definer) receive
+ * the target handle as an argument, so the closure only captures values stable
+ * for the whole Arena lifetime (`ctx`, `unmarshal`, `syncMode`, `proxyKeySymbol`).
+ * The proxyFuncs handle is created lazily on first use and must be disposed once
+ * via `dispose()`; the VM-side Proxy keeps its own reference to it, so it stays
+ * valid for every proxy created during the Arena's lifetime.
+ */
+export function createWrapHandle(
   ctx: QuickJSContext,
-  handle: QuickJSHandle,
   proxyKeySymbol: symbol,
   proxyKeySymbolHandle: QuickJSHandle,
   unmarshal: (handle: QuickJSHandle) => any,
   syncMode?: (target: QuickJSHandle) => SyncMode | undefined,
   wrappable?: (target: QuickJSHandle, ctx: QuickJSContext) => boolean,
   syncEnabled = true,
-): [Wrapped<QuickJSHandle> | undefined, boolean] {
-  if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
-    return [undefined, false];
-
-  if (isHandleWrapped(ctx, handle, proxyKeySymbolHandle)) return [handle, false];
-
-  // Sync globally disabled: skip the VM-side proxy.
-  if (!syncEnabled) return [handle as Wrapped<QuickJSHandle>, false];
+): WrapHandle {
+  let proxyFuncs: QuickJSHandle | undefined;
 
   const getSyncMode = (h: QuickJSHandle) => {
     const res = syncMode?.(unmarshal(h));
@@ -162,26 +173,43 @@ export function wrapHandle(
     Object.defineProperty(unwrap(target, proxyKeySymbol), key, desc);
   };
 
-  const proxyFuncs = ctx.newFunction("proxyFuncs", (t, ...args) => {
-    const name = ctx.getNumber(t);
-    switch (name) {
-      case 1:
-        return getSyncMode(args[0]);
-      case 2:
-        return setter(args[0], args[1], args[2]);
-      case 3:
-        return deleter(args[0], args[1]);
-      case 4:
-        return definer(args[0], args[1], args[2]);
-    }
-    return ctx.undefined;
-  });
-  // Use the exception-safe consume so proxyFuncs is disposed even if compiling
-  // the proxy below throws (e.g. under memory pressure).
-  return consume(proxyFuncs, proxyFuncs => [
-    call(
-      ctx,
-      `(target, sym, proxyFuncs) => {
+  const ensureProxyFuncs = (): QuickJSHandle => {
+    if (proxyFuncs && proxyFuncs.alive) return proxyFuncs;
+    proxyFuncs = ctx.newFunction("proxyFuncs", (t, ...args) => {
+      const name = ctx.getNumber(t);
+      switch (name) {
+        case 1:
+          return getSyncMode(args[0]);
+        case 2:
+          return setter(args[0], args[1], args[2]);
+        case 3:
+          return deleter(args[0], args[1]);
+        case 4:
+          return definer(args[0], args[1], args[2]);
+      }
+      return ctx.undefined;
+    });
+    return proxyFuncs;
+  };
+
+  const wrapHandleFn = (
+    handle: QuickJSHandle,
+  ): [Wrapped<QuickJSHandle> | undefined, boolean] => {
+    if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
+      return [undefined, false];
+
+    if (isHandleWrapped(ctx, handle, proxyKeySymbolHandle)) return [handle, false];
+
+    // Sync globally disabled: skip the VM-side proxy.
+    if (!syncEnabled) return [handle as Wrapped<QuickJSHandle>, false];
+
+    // The shared proxyFuncs is borrowed (not consumed) by `call`, and the
+    // VM-side Proxy keeps its own reference, so it stays alive for the whole
+    // Arena lifetime and is disposed once via `dispose()` even if `call` throws.
+    return [
+      call(
+        ctx,
+        `(target, sym, proxyFuncs) => {
           const rec =  new Proxy(target, {
             get(obj, key, receiver) {
               return key === sym ? obj : Reflect.get(obj, key, receiver)
@@ -219,13 +247,53 @@ export function wrapHandle(
           });
           return rec;
         }`,
-      undefined,
-      handle,
-      proxyKeySymbolHandle,
-      proxyFuncs,
-    ) as Wrapped<QuickJSHandle>,
-    true,
-  ]);
+        undefined,
+        handle,
+        proxyKeySymbolHandle,
+        ensureProxyFuncs(),
+      ) as Wrapped<QuickJSHandle>,
+      true,
+    ];
+  };
+
+  return {
+    wrapHandle: wrapHandleFn,
+    dispose: () => {
+      if (proxyFuncs && proxyFuncs.alive) proxyFuncs.dispose();
+      proxyFuncs = undefined;
+    },
+  };
+}
+
+/**
+ * Standalone wrap of a single handle. Builds a one-shot {@link createWrapHandle}
+ * and disposes its proxyFuncs right after; the VM-side Proxy keeps its own
+ * reference, so the wrapped handle stays valid.
+ */
+export function wrapHandle(
+  ctx: QuickJSContext,
+  handle: QuickJSHandle,
+  proxyKeySymbol: symbol,
+  proxyKeySymbolHandle: QuickJSHandle,
+  unmarshal: (handle: QuickJSHandle) => any,
+  syncMode?: (target: QuickJSHandle) => SyncMode | undefined,
+  wrappable?: (target: QuickJSHandle, ctx: QuickJSContext) => boolean,
+  syncEnabled = true,
+): [Wrapped<QuickJSHandle> | undefined, boolean] {
+  const w = createWrapHandle(
+    ctx,
+    proxyKeySymbol,
+    proxyKeySymbolHandle,
+    unmarshal,
+    syncMode,
+    wrappable,
+    syncEnabled,
+  );
+  try {
+    return w.wrapHandle(handle);
+  } finally {
+    w.dispose();
+  }
 }
 
 export function unwrap<T>(obj: T, key: string | symbol): T {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -198,18 +198,32 @@ export function createWrapHandle(
     if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
       return [undefined, false];
 
-    if (isHandleWrapped(ctx, handle, proxyKeySymbolHandle)) return [handle, false];
-
-    // Sync globally disabled: skip the VM-side proxy.
+    // Sync globally disabled: skip the VM-side proxy. (When wrapped or built-in
+    // the old path also returned `[handle, false]`, so this order is equivalent
+    // and avoids the extra check entirely.)
     if (!syncEnabled) return [handle as Wrapped<QuickJSHandle>, false];
 
+    // The "already wrapped / must-not-wrap built-in" test is folded into the
+    // proxy-creating VM call: it returns `null` when it declines (built-in with
+    // internal slots, or `target[sym]` already set), so we pay ONE roundtrip
+    // instead of a separate `isHandleWrapped` call plus the wrap. A declined
+    // handle is treated as already-wrapped by returning the ORIGINAL handle.
+    //
     // The shared proxyFuncs is borrowed (not consumed) by `call`, and the
     // VM-side Proxy keeps its own reference, so it stays alive for the whole
     // Arena lifetime and is disposed once via `dispose()` even if `call` throws.
-    return [
-      call(
-        ctx,
-        `(target, sym, proxyFuncs) => {
+    const result = call(
+      ctx,
+      `(target, sym, proxyFuncs) => {
+          if (
+            (target instanceof Promise) ||
+            (target instanceof Date) ||
+            (target instanceof ArrayBuffer) ||
+            (ArrayBuffer.isView(target)) ||
+            (target instanceof Map) ||
+            (target instanceof Set) ||
+            target[sym]
+          ) return null;
           const rec =  new Proxy(target, {
             get(obj, key, receiver) {
               return key === sym ? obj : Reflect.get(obj, key, receiver)
@@ -247,13 +261,21 @@ export function createWrapHandle(
           });
           return rec;
         }`,
-        undefined,
-        handle,
-        proxyKeySymbolHandle,
-        ensureProxyFuncs(),
-      ) as Wrapped<QuickJSHandle>,
-      true,
-    ];
+      undefined,
+      handle,
+      proxyKeySymbolHandle,
+      ensureProxyFuncs(),
+    );
+
+    // Declined: the VM function returned null. Detect it with cheap host-side
+    // checks (no callFunction), dispose the null result, and treat the original
+    // handle as already-wrapped.
+    if (ctx.sameValue(result, ctx.null)) {
+      result.dispose();
+      return [handle as Wrapped<QuickJSHandle>, false];
+    }
+
+    return [result as Wrapped<QuickJSHandle>, true];
   };
 
   return {
@@ -305,8 +327,22 @@ export function unwrapHandle(
   handle: QuickJSHandle,
   key: QuickJSHandle,
 ): [QuickJSHandle, boolean] {
-  if (!isHandleWrapped(ctx, handle, key)) return [handle, false];
-  return [ctx.getProp(handle, key), true];
+  // Fold the `isHandleWrapped` test and the property read into ONE VM call:
+  // return the unwrapped target (`a[sym]`) or null. This pays a single roundtrip
+  // instead of `isHandleWrapped` + `getProp`. A null result means "not wrapped",
+  // so the original handle is used as-is.
+  const result = call(
+    ctx,
+    `(a, s) => (typeof a === "object" && a !== null || typeof a === "function") && a[s] || null`,
+    undefined,
+    handle,
+    key,
+  );
+  if (ctx.sameValue(result, ctx.null)) {
+    result.dispose();
+    return [handle, false];
+  }
+  return [result, true];
 }
 
 export function isWrapped<T>(obj: T, key: string | symbol): obj is Wrapped<T> {


### PR DESCRIPTION
Stacked on #94 (which is stacked on #93); will be retargeted as the base PRs merge.

## Summary
- `Arena.evalCode`, `Arena.evalModule`, and `AsyncArena.evalCodeAsync` now accept optional `filename` and `options` (`number | ContextEvalOptions`) params, forwarded to quickjs-emscripten.
- `evalModule` merges user-supplied options but always forces `type: "module"`; numeric `EvalFlags` bitmasks passed to `evalModule` are ignored (documented in JSDoc).
- Adds `Arena.setInterruptHandler(cb)` / `Arena.removeInterruptHandler()` passthroughs. Combined with the existing `setMemoryLimit`, this covers the practical intent of the issue's `ModuleEvalOptions` ask: eval flags, memory limits, and interruption.
- `ContextEvalOptions` and `InterruptHandler` types are re-exported.
- 4 new tests: strict mode, filename in error stacks, evalModule option merging, interrupt handler stopping an infinite loop.

## Verification
176 tests / typecheck / lint all pass.

Closes #38