### PR TITLE
perf: per-property fast paths in marshal/unmarshal properties

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,6 +73,70 @@ describe("readme", () => {
   });
 });
 
+describe("class constructors (#92)", () => {
+  test("new on an exposed class inside the VM", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      hoge = "";
+
+      constructor() {
+        this.hoge = "foo";
+      }
+    }
+    arena.expose({ Cls });
+
+    const instance = arena.evalCode(`new Cls()`) as { hoge: string };
+    expect(instance.hoge).toBe("foo");
+    expect(arena.evalCode(`new Cls() instanceof Cls`)).toBe(true);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("constructor arguments reach the host", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      value: number;
+
+      constructor(a: number, b: number) {
+        this.value = a + b;
+      }
+    }
+    arena.expose({ Cls });
+
+    const instance = arena.evalCode(`new Cls(2, 3)`) as { value: number };
+    expect(instance.value).toBe(5);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("new on a synced class inside the VM", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      hoge = "";
+
+      constructor(v = "foo") {
+        this.hoge = v;
+      }
+    }
+    arena.expose({ Cls: arena.sync(Cls) });
+
+    const instance = arena.evalCode(`new Cls("bar")`) as { hoge: string };
+    expect(instance.hoge).toBe("bar");
+    expect(arena.evalCode(`new Cls() instanceof Cls`)).toBe(true);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+});
+
 describe("evalCode", () => {
   test("simple object and function", async () => {
     const ctx = (await getQuickJS()).newContext();

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,6 +491,7 @@ export class Arena {
       disposeTransient: this._disposeTransient,
       preApply: this._marshalPreApply,
       prepareReturn: this._prepareMarshalReturn,
+      unwrap: t => this._unwrap(t),
       custom: this._options?.customMarshaller,
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { defaultRegisteredObjects } from "./default";
 import marshal from "./marshal";
 import unmarshal from "./unmarshal";
 import unmarshalHostRef from "./unmarshal/hostref";
+import unmarshalPrimitive from "./unmarshal/primitive";
 import { complexity, isES2015Class, isObject, walkObject } from "./util";
 import VMMap from "./vmmap";
 import {
@@ -523,6 +524,14 @@ export class Arena {
   };
 
   _unmarshal = (handle: QuickJSHandle): any => {
+    // Primitives (undefined/number/string/boolean/bigint/null) are resolved by a
+    // cheap host-side `ctx.typeof`, skipping the `_registeredMap` VM lookup,
+    // HostRef resolution, and `_wrapHandle`. The VMMap only ever keys objects and
+    // symbols, so a primitive handle can never match `getByHandle`; symbols fall
+    // through `unmarshalPrimitive` and still reach the lookup below.
+    const [primitive, ok] = unmarshalPrimitive(this.context, handle);
+    if (ok) return primitive;
+
     const registered = this._registeredMap.getByHandle(handle);
     if (typeof registered !== "undefined") {
       return registered;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
   enableFnCache,
   disposeFnCache,
 } from "./vmutil";
-import { wrap, wrapHandle, unwrap, unwrapHandle, Wrapped } from "./wrapper";
+import { wrap, createWrapHandle, unwrap, unwrapHandle, Wrapped, WrapHandle } from "./wrapper";
 
 export {
   VMMap,
@@ -92,6 +92,7 @@ export class Arena {
   _temporalSync = new Set<any>();
   _symbol = Symbol();
   _symbolHandle: QuickJSHandle;
+  _wrapHandleImpl: WrapHandle;
   _options?: Options;
 
   /** Constructs a new Arena instance. It requires a quickjs-emscripten context initialized with `quickjs.newContext()`. */
@@ -108,6 +109,17 @@ export class Arena {
     enableFnCache(this.context);
     this._options = options;
     this._symbolHandle = ctx.unwrapResult(ctx.evalCode(`Symbol()`));
+    // One proxyFuncs handle shared by every wrapped handle for the Arena's
+    // lifetime, instead of allocating a fresh VM function per wrap.
+    this._wrapHandleImpl = createWrapHandle(
+      this.context,
+      this._symbol,
+      this._symbolHandle,
+      this._unmarshal,
+      this._syncMode,
+      this._options?.isHandleWrappable,
+      this._options?.syncEnabled ?? true,
+    );
     this._map = new VMMap(ctx);
     this._registeredMap = new VMMap(ctx);
     this.registerAll(options?.registeredObjects ?? defaultRegisteredObjects);
@@ -123,6 +135,7 @@ export class Arena {
     this._transientHandles.clear();
     this._map.dispose();
     this._registeredMap.dispose();
+    this._wrapHandleImpl.dispose();
     this._symbolHandle.dispose();
     disposeFnCache(this.context);
     this.context.disposeEx?.();
@@ -622,16 +635,7 @@ export class Arena {
   };
 
   _wrapHandle(handle: QuickJSHandle): [Wrapped<QuickJSHandle> | undefined, boolean] {
-    return wrapHandle(
-      this.context,
-      handle,
-      this._symbol,
-      this._symbolHandle,
-      this._unmarshal,
-      this._syncMode,
-      this._options?.isHandleWrappable,
-      this._options?.syncEnabled ?? true,
-    );
+    return this._wrapHandleImpl.wrapHandle(handle);
   }
 
   _unwrapHandle(target: QuickJSHandle): [QuickJSHandle, boolean] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,7 +501,11 @@ export class Arena {
     this._transientHandles.delete(handle);
 
     const syncEnabled = this._options?.syncEnabled ?? true;
-    return [handle, !syncEnabled || !this._map.hasHandle(handle)];
+    // A non-object (primitive) handle is never retained in `_map` (registered
+    // primitives already returned above via `_registeredMap`), so skip the
+    // `hasHandle` VM roundtrip and mark it disposable directly.
+    if (!syncEnabled || !isObject(target)) return [handle, true];
+    return [handle, !this._map.hasHandle(handle)];
   };
 
   _prepareMarshalReturn = (h: QuickJSHandle): QuickJSHandle => {
@@ -512,7 +516,12 @@ export class Arena {
     // `x === fn()` identity across calls. Hand the VM a dup instead and keep
     // ours alive. With sync off, handles are not retained, so this is a no-op.
     const syncEnabled = this._options?.syncEnabled ?? true;
-    return syncEnabled && h.alive && this._map.hasHandle(h) ? h.dup() : h;
+    // Only object handles are retained in `_map`; a primitive return can never
+    // be in the map, so `isHandleObject` (a cheap typeof) skips the `hasHandle`
+    // VM roundtrip for primitive returns from host functions.
+    return syncEnabled && h.alive && isHandleObject(this.context, h) && this._map.hasHandle(h)
+      ? h.dup()
+      : h;
   };
 
   _preUnmarshal = (t: any, h: QuickJSHandle): Wrapped<any> => {

--- a/src/marshal/function.ts
+++ b/src/marshal/function.ts
@@ -14,8 +14,15 @@ export default function marshalFunction(
   preApply?: (target: (...args: any[]) => any, thisArg: unknown, args: unknown[]) => any,
   disposeTransient: (handle: QuickJSHandle) => void = () => {},
   prepareReturn: (handle: QuickJSHandle) => QuickJSHandle = h => h,
+  unwrap: (target: unknown) => unknown = t => t,
 ): QuickJSHandle | undefined {
   if (typeof target !== "function") return;
+
+  // `target` may be a host-side proxy wrapper; unwrap it before the class check,
+  // because Function.prototype.toString on a callable proxy never matches /^class/.
+  // Computed once here rather than per call to avoid the toString + regex on every
+  // VM→host invocation.
+  const isClass = isES2015Class(unwrap(target));
 
   const raw = ctx
     .newFunction(target.name, function (...argHandles) {
@@ -29,9 +36,9 @@ export default function marshalFunction(
       const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
       const args = argHandles.map(a => unmarshal(a));
 
-      if (isES2015Class(target) && isObject(that)) {
+      if (isClass && isObject(that)) {
         // Class constructors cannot be invoked without new expression, and new.target is not changed
-        const result = new target(...args);
+        const result = new (target as new (...args: any[]) => any)(...args);
         Object.entries(result).forEach(([key, value]) => {
           const valueHandle = marshal(value);
           ctx.setProp(this, key, valueHandle);

--- a/src/marshal/index.ts
+++ b/src/marshal/index.ts
@@ -33,6 +33,9 @@ export type Options = {
   // the VMMap retains (for identity, while sync is on) must be dup'd here or its
   // map entry goes stale. Defaults to identity (no-op).
   prepareReturn?: (handle: QuickJSHandle) => QuickJSHandle;
+  // Strip a host-side proxy wrapper from a target. Used to detect a wrapped class
+  // constructor, which would otherwise be hidden behind the proxy. Defaults to identity.
+  unwrap?: (target: unknown) => unknown;
   custom?: Iterable<(obj: unknown, ctx: QuickJSContext) => QuickJSHandle | undefined>;
 };
 
@@ -87,6 +90,7 @@ export function marshal(target: unknown, options: Options): QuickJSHandle {
       options.preApply,
       disposeTransient,
       options.prepareReturn,
+      options.unwrap,
     ) ??
     marshalMapSet(ctx, target, marshal2, pre2, disposeTransient) ??
     marshalObject(ctx, target, marshal2, pre2, disposeTransient) ??

--- a/src/marshal/properties.ts
+++ b/src/marshal/properties.ts
@@ -9,12 +9,55 @@ export default function marshalProperties(
   marshal: (target: unknown) => QuickJSHandle,
   disposeTransient: (handle: QuickJSHandle) => void = () => {},
 ): void {
-  const descs = ctx.newObject();
-  // Property values may be transient (json copies / BigInt) with no owner; once
-  // `Object.defineProperties` has copied them into `handle` the standalone
-  // handles are redundant and disposed below. Owned handles are left untouched.
+  // `descs` aggregates only the properties that need the full descriptor path
+  // (accessors, non-default flags, symbol keys). It is created lazily so plain
+  // objects/arrays skip both the `ctx.newObject()` and the final
+  // `Object.defineProperties` roundtrip entirely.
+  let descs: QuickJSHandle | undefined;
+  // Descriptor-path values may be transient (json copies / BigInt) with no
+  // owner; once `Object.defineProperties` has copied them into `handle` the
+  // standalone handles are redundant and disposed below. Owned handles are left
+  // untouched. Fast-path values are disposed inline (see below).
   const transient: QuickJSHandle[] = [];
+
+  // `ctx.setProp` uses `[[Set]]` semantics, which walks the prototype chain and
+  // would invoke an inherited accessor/setter (or the `__proto__` setter)
+  // instead of creating an own property. That only matters when `marshalObject`
+  // installed a custom prototype (see marshal/object.ts): a default-prototype VM
+  // object (plain object / array) has no shadowing accessors, so `setProp` on a
+  // normal string key is identical to `defineProperty` with all flags true. For
+  // custom-prototype objects (e.g. class instances) we must keep the descriptor
+  // path, which uses `[[DefineOwnProperty]]` semantics.
+  const proto = Object.getPrototypeOf(target);
+  const defaultProto = proto === Object.prototype || proto === Array.prototype;
+
   const cb = (key: string | number | symbol, desc: PropertyDescriptor) => {
+    // Fast path: a plain data property with a string key and all flags at their
+    // defaults, on a default-prototype object, is semantically identical to
+    // `ctx.setProp` on a fresh object/array, so we skip building a descriptor
+    // object. `writable === true` implies a data descriptor (accessors have no
+    // `writable`), so there is no get/set. Symbol keys keep the descriptor path
+    // (setProp string-key fast path does not apply). `__proto__` is excluded
+    // because it resolves to the prototype setter under `[[Set]]`. The value is
+    // copied into `handle` by setProp immediately, so its transient handle can
+    // be disposed right away.
+    if (
+      defaultProto &&
+      typeof key === "string" &&
+      key !== "__proto__" &&
+      desc.writable === true &&
+      desc.enumerable === true &&
+      desc.configurable === true &&
+      desc.get === undefined &&
+      desc.set === undefined
+    ) {
+      const keyHandle = marshal(key);
+      const valueHandle = marshal(desc.value);
+      ctx.setProp(handle, keyHandle, valueHandle);
+      disposeTransient(valueHandle);
+      return;
+    }
+
     const keyHandle = marshal(key);
     const valueHandle = typeof desc.value === "undefined" ? undefined : marshal(desc.value);
     const getHandle = typeof desc.get === "undefined" ? undefined : marshal(desc.get);
@@ -23,6 +66,7 @@ export default function marshalProperties(
     if (getHandle) transient.push(getHandle);
     if (setHandle) transient.push(setHandle);
 
+    const descsHandle = (descs ??= ctx.newObject());
     ctx.newObject().consume(descObj => {
       Object.entries(desc).forEach(([k, v]) => {
         const v2 =
@@ -39,7 +83,7 @@ export default function marshalProperties(
           ctx.setProp(descObj, k, v2);
         }
       });
-      ctx.setProp(descs, keyHandle, descObj);
+      ctx.setProp(descsHandle, keyHandle, descObj);
     });
   };
 
@@ -48,11 +92,13 @@ export default function marshalProperties(
     Object.entries(desc).forEach(([k, v]) => cb(k, v));
     Object.getOwnPropertySymbols(desc).forEach(k => cb(k, (desc as any)[k]));
 
-    call(ctx, `Object.defineProperties`, undefined, handle, descs).dispose();
-    // Safe only after defineProperties has dup'd the values into `handle`; `descs`
-    // still holds its own references until its own dispose() in the finally.
-    for (const h of transient) disposeTransient(h);
+    if (descs) {
+      call(ctx, `Object.defineProperties`, undefined, handle, descs).dispose();
+      // Safe only after defineProperties has dup'd the values into `handle`;
+      // `descs` still holds its own references until its own dispose() below.
+      for (const h of transient) disposeTransient(h);
+    }
   } finally {
-    descs.dispose();
+    descs?.dispose();
   }
 }

--- a/src/unmarshal/properties.ts
+++ b/src/unmarshal/properties.ts
@@ -2,6 +2,46 @@ import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
 
 import { call, consume } from "../vmutil";
 
+// The VM-side iterator computes a numeric bitmask per property so the host can
+// rebuild the PropertyDescriptor with at most one `ctx.getProp` (for the single
+// value/get/set entry that is actually present) plus one `ctx.getNumber`,
+// instead of the previous six `getProp` + six `typeof` calls per property.
+//
+// Bit layout (a "present" bit for every field, plus a "value" bit for the three
+// boolean fields whose value we cannot recover from a handle):
+//   bit 0 (1)   value present        (typeof d.value !== "undefined")
+//   bit 1 (2)   get present          (typeof d.get   !== "undefined")
+//   bit 2 (4)   set present          (typeof d.set   !== "undefined")
+//   bit 3 (8)   configurable present (typeof d.configurable === "boolean")
+//   bit 4 (16)  configurable value   (d.configurable === true)
+//   bit 5 (32)  enumerable present   (typeof d.enumerable === "boolean")
+//   bit 6 (64)  enumerable value     (d.enumerable === true)
+//   bit 7 (128) writable present     (typeof d.writable === "boolean")
+//   bit 8 (256) writable value       (d.writable === true)
+//
+// This mirrors the previous logic exactly: value/get/set are copied only when
+// defined (an explicit `value: undefined` is treated as absent, so defaults
+// apply, just as `typeof === "undefined"` skipped it before); a boolean field
+// is copied only when actually a boolean, and absent boolean fields stay absent
+// so `Object.defineProperty` applies its defaults. Data vs accessor descriptors
+// are distinguished naturally: data descriptors carry a `writable` present bit
+// and no get/set, accessors carry get/set and no `writable`.
+const flagsFn = `(o, fn) => {
+  const descs = Object.getOwnPropertyDescriptors(o);
+  const emit = (k, d) => {
+    let f = 0;
+    if (typeof d.value !== "undefined") f |= 1;
+    if (typeof d.get !== "undefined") f |= 2;
+    if (typeof d.set !== "undefined") f |= 4;
+    if (typeof d.configurable === "boolean") { f |= 8; if (d.configurable) f |= 16; }
+    if (typeof d.enumerable === "boolean") { f |= 32; if (d.enumerable) f |= 64; }
+    if (typeof d.writable === "boolean") { f |= 128; if (d.writable) f |= 256; }
+    fn(k, d, f);
+  };
+  Object.entries(descs).forEach(([k, v]) => emit(k, v));
+  Object.getOwnPropertySymbols(descs).forEach(k => emit(k, descs[k]));
+}`;
+
 export default function unmarshalProperties(
   ctx: QuickJSContext,
   handle: QuickJSHandle,
@@ -9,53 +49,38 @@ export default function unmarshalProperties(
   unmarshal: (handle: QuickJSHandle) => [unknown, boolean],
 ) {
   consume(
-    ctx.newFunction("", (key, value) => {
+    ctx.newFunction("", (key, descHandle, flagsHandle) => {
       const [keyName] = unmarshal(key);
       if (typeof keyName !== "string" && typeof keyName !== "number" && typeof keyName !== "symbol")
         return;
 
-      const desc = (
-        [
-          ["value", true],
-          ["get", true],
-          ["set", true],
-          ["configurable", false],
-          ["enumerable", false],
-          ["writable", false],
-        ] as const
-      ).reduce<PropertyDescriptor>((desc, [key, unmarshable]) => {
-        const h = ctx.getProp(value, key);
-        const ty = ctx.typeof(h);
+      const flags = ctx.getNumber(flagsHandle);
+      const desc: PropertyDescriptor = {};
 
-        if (ty === "undefined") return desc;
-        if (!unmarshable && ty === "boolean") {
-          desc[key] = ctx.dump(ctx.getProp(value, key));
-          return desc;
-        }
-
+      // Obtain value/get/set as host-owned handles via `ctx.getProp` exactly as
+      // before: these must NOT come from the (scope-borrowed, auto-disposed)
+      // callback arguments, because `unmarshal` may retain the handle in the
+      // Arena's VMMap for identity tracking. Dispose only when `unmarshal`
+      // reports the value already existed (so the fresh handle is redundant);
+      // otherwise ownership was transferred to the map and we must keep it.
+      const readHandle = (fieldKey: string): unknown => {
+        const h = ctx.getProp(descHandle, fieldKey);
         const [v, alreadyExists] = unmarshal(h);
-        if (alreadyExists) {
-          h.dispose();
-        }
-        desc[key] = v;
+        if (alreadyExists) h.dispose();
+        return v;
+      };
 
-        return desc;
-      }, {});
+      if (flags & 1) desc.value = readHandle("value");
+      if (flags & 2) desc.get = readHandle("get") as any;
+      if (flags & 4) desc.set = readHandle("set") as any;
+      if (flags & 8) desc.configurable = !!(flags & 16);
+      if (flags & 32) desc.enumerable = !!(flags & 64);
+      if (flags & 128) desc.writable = !!(flags & 256);
 
       Object.defineProperty(target, keyName, desc);
     }),
     fn => {
-      call(
-        ctx,
-        `(o, fn) => {
-        const descs = Object.getOwnPropertyDescriptors(o);
-        Object.entries(descs).forEach(([k, v]) => fn(k, v));
-        Object.getOwnPropertySymbols(descs).forEach(k => fn(k, descs[k]));
-      }`,
-        undefined,
-        handle,
-        fn,
-      ).dispose();
+      call(ctx, flagsFn, undefined, handle, fn).dispose();
     },
   );
 }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,7 +1,7 @@
 import type { QuickJSHandle, QuickJSContext } from "quickjs-emscripten";
 
 import { isObject } from "./util";
-import { call, consume, isHandleObject, mayConsumeAll } from "./vmutil";
+import { call, isHandleObject, mayConsumeAll } from "./vmutil";
 
 export type SyncMode = "both" | "vm" | "host";
 
@@ -113,23 +113,34 @@ export function wrap<T = any>(
   return rec;
 }
 
-export function wrapHandle(
+export type WrapHandle = {
+  /** Wrap a VM handle with the shared proxyFuncs, like the old `wrapHandle`. */
+  wrapHandle: (handle: QuickJSHandle) => [Wrapped<QuickJSHandle> | undefined, boolean];
+  /** Dispose the shared proxyFuncs handle. Call exactly once, at Arena dispose. */
+  dispose: () => void;
+};
+
+/**
+ * Build a `wrapHandle` function that shares ONE `proxyFuncs` handle across every
+ * handle it wraps, instead of allocating a fresh VM function per wrapped object.
+ *
+ * The callbacks inside proxyFuncs (getSyncMode/setter/deleter/definer) receive
+ * the target handle as an argument, so the closure only captures values stable
+ * for the whole Arena lifetime (`ctx`, `unmarshal`, `syncMode`, `proxyKeySymbol`).
+ * The proxyFuncs handle is created lazily on first use and must be disposed once
+ * via `dispose()`; the VM-side Proxy keeps its own reference to it, so it stays
+ * valid for every proxy created during the Arena's lifetime.
+ */
+export function createWrapHandle(
   ctx: QuickJSContext,
-  handle: QuickJSHandle,
   proxyKeySymbol: symbol,
   proxyKeySymbolHandle: QuickJSHandle,
   unmarshal: (handle: QuickJSHandle) => any,
   syncMode?: (target: QuickJSHandle) => SyncMode | undefined,
   wrappable?: (target: QuickJSHandle, ctx: QuickJSContext) => boolean,
   syncEnabled = true,
-): [Wrapped<QuickJSHandle> | undefined, boolean] {
-  if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
-    return [undefined, false];
-
-  if (isHandleWrapped(ctx, handle, proxyKeySymbolHandle)) return [handle, false];
-
-  // Sync globally disabled: skip the VM-side proxy.
-  if (!syncEnabled) return [handle as Wrapped<QuickJSHandle>, false];
+): WrapHandle {
+  let proxyFuncs: QuickJSHandle | undefined;
 
   const getSyncMode = (h: QuickJSHandle) => {
     const res = syncMode?.(unmarshal(h));
@@ -162,26 +173,43 @@ export function wrapHandle(
     Object.defineProperty(unwrap(target, proxyKeySymbol), key, desc);
   };
 
-  const proxyFuncs = ctx.newFunction("proxyFuncs", (t, ...args) => {
-    const name = ctx.getNumber(t);
-    switch (name) {
-      case 1:
-        return getSyncMode(args[0]);
-      case 2:
-        return setter(args[0], args[1], args[2]);
-      case 3:
-        return deleter(args[0], args[1]);
-      case 4:
-        return definer(args[0], args[1], args[2]);
-    }
-    return ctx.undefined;
-  });
-  // Use the exception-safe consume so proxyFuncs is disposed even if compiling
-  // the proxy below throws (e.g. under memory pressure).
-  return consume(proxyFuncs, proxyFuncs => [
-    call(
-      ctx,
-      `(target, sym, proxyFuncs) => {
+  const ensureProxyFuncs = (): QuickJSHandle => {
+    if (proxyFuncs && proxyFuncs.alive) return proxyFuncs;
+    proxyFuncs = ctx.newFunction("proxyFuncs", (t, ...args) => {
+      const name = ctx.getNumber(t);
+      switch (name) {
+        case 1:
+          return getSyncMode(args[0]);
+        case 2:
+          return setter(args[0], args[1], args[2]);
+        case 3:
+          return deleter(args[0], args[1]);
+        case 4:
+          return definer(args[0], args[1], args[2]);
+      }
+      return ctx.undefined;
+    });
+    return proxyFuncs;
+  };
+
+  const wrapHandleFn = (
+    handle: QuickJSHandle,
+  ): [Wrapped<QuickJSHandle> | undefined, boolean] => {
+    if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
+      return [undefined, false];
+
+    if (isHandleWrapped(ctx, handle, proxyKeySymbolHandle)) return [handle, false];
+
+    // Sync globally disabled: skip the VM-side proxy.
+    if (!syncEnabled) return [handle as Wrapped<QuickJSHandle>, false];
+
+    // The shared proxyFuncs is borrowed (not consumed) by `call`, and the
+    // VM-side Proxy keeps its own reference, so it stays alive for the whole
+    // Arena lifetime and is disposed once via `dispose()` even if `call` throws.
+    return [
+      call(
+        ctx,
+        `(target, sym, proxyFuncs) => {
           const rec =  new Proxy(target, {
             get(obj, key, receiver) {
               return key === sym ? obj : Reflect.get(obj, key, receiver)
@@ -219,13 +247,53 @@ export function wrapHandle(
           });
           return rec;
         }`,
-      undefined,
-      handle,
-      proxyKeySymbolHandle,
-      proxyFuncs,
-    ) as Wrapped<QuickJSHandle>,
-    true,
-  ]);
+        undefined,
+        handle,
+        proxyKeySymbolHandle,
+        ensureProxyFuncs(),
+      ) as Wrapped<QuickJSHandle>,
+      true,
+    ];
+  };
+
+  return {
+    wrapHandle: wrapHandleFn,
+    dispose: () => {
+      if (proxyFuncs && proxyFuncs.alive) proxyFuncs.dispose();
+      proxyFuncs = undefined;
+    },
+  };
+}
+
+/**
+ * Standalone wrap of a single handle. Builds a one-shot {@link createWrapHandle}
+ * and disposes its proxyFuncs right after; the VM-side Proxy keeps its own
+ * reference, so the wrapped handle stays valid.
+ */
+export function wrapHandle(
+  ctx: QuickJSContext,
+  handle: QuickJSHandle,
+  proxyKeySymbol: symbol,
+  proxyKeySymbolHandle: QuickJSHandle,
+  unmarshal: (handle: QuickJSHandle) => any,
+  syncMode?: (target: QuickJSHandle) => SyncMode | undefined,
+  wrappable?: (target: QuickJSHandle, ctx: QuickJSContext) => boolean,
+  syncEnabled = true,
+): [Wrapped<QuickJSHandle> | undefined, boolean] {
+  const w = createWrapHandle(
+    ctx,
+    proxyKeySymbol,
+    proxyKeySymbolHandle,
+    unmarshal,
+    syncMode,
+    wrappable,
+    syncEnabled,
+  );
+  try {
+    return w.wrapHandle(handle);
+  } finally {
+    w.dispose();
+  }
 }
 
 export function unwrap<T>(obj: T, key: string | symbol): T {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -198,18 +198,32 @@ export function createWrapHandle(
     if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
       return [undefined, false];
 
-    if (isHandleWrapped(ctx, handle, proxyKeySymbolHandle)) return [handle, false];
-
-    // Sync globally disabled: skip the VM-side proxy.
+    // Sync globally disabled: skip the VM-side proxy. (When wrapped or built-in
+    // the old path also returned `[handle, false]`, so this order is equivalent
+    // and avoids the extra check entirely.)
     if (!syncEnabled) return [handle as Wrapped<QuickJSHandle>, false];
 
+    // The "already wrapped / must-not-wrap built-in" test is folded into the
+    // proxy-creating VM call: it returns `null` when it declines (built-in with
+    // internal slots, or `target[sym]` already set), so we pay ONE roundtrip
+    // instead of a separate `isHandleWrapped` call plus the wrap. A declined
+    // handle is treated as already-wrapped by returning the ORIGINAL handle.
+    //
     // The shared proxyFuncs is borrowed (not consumed) by `call`, and the
     // VM-side Proxy keeps its own reference, so it stays alive for the whole
     // Arena lifetime and is disposed once via `dispose()` even if `call` throws.
-    return [
-      call(
-        ctx,
-        `(target, sym, proxyFuncs) => {
+    const result = call(
+      ctx,
+      `(target, sym, proxyFuncs) => {
+          if (
+            (target instanceof Promise) ||
+            (target instanceof Date) ||
+            (target instanceof ArrayBuffer) ||
+            (ArrayBuffer.isView(target)) ||
+            (target instanceof Map) ||
+            (target instanceof Set) ||
+            target[sym]
+          ) return null;
           const rec =  new Proxy(target, {
             get(obj, key, receiver) {
               return key === sym ? obj : Reflect.get(obj, key, receiver)
@@ -247,13 +261,21 @@ export function createWrapHandle(
           });
           return rec;
         }`,
-        undefined,
-        handle,
-        proxyKeySymbolHandle,
-        ensureProxyFuncs(),
-      ) as Wrapped<QuickJSHandle>,
-      true,
-    ];
+      undefined,
+      handle,
+      proxyKeySymbolHandle,
+      ensureProxyFuncs(),
+    );
+
+    // Declined: the VM function returned null. Detect it with cheap host-side
+    // checks (no callFunction), dispose the null result, and treat the original
+    // handle as already-wrapped.
+    if (ctx.sameValue(result, ctx.null)) {
+      result.dispose();
+      return [handle as Wrapped<QuickJSHandle>, false];
+    }
+
+    return [result as Wrapped<QuickJSHandle>, true];
   };
 
   return {
@@ -305,8 +327,22 @@ export function unwrapHandle(
   handle: QuickJSHandle,
   key: QuickJSHandle,
 ): [QuickJSHandle, boolean] {
-  if (!isHandleWrapped(ctx, handle, key)) return [handle, false];
-  return [ctx.getProp(handle, key), true];
+  // Fold the `isHandleWrapped` test and the property read into ONE VM call:
+  // return the unwrapped target (`a[sym]`) or null. This pays a single roundtrip
+  // instead of `isHandleWrapped` + `getProp`. A null result means "not wrapped",
+  // so the original handle is used as-is.
+  const result = call(
+    ctx,
+    `(a, s) => (typeof a === "object" && a !== null || typeof a === "function") && a[s] || null`,
+    undefined,
+    handle,
+    key,
+  );
+  if (ctx.sameValue(result, ctx.null)) {
+    result.dispose();
+    return [handle, false];
+  }
+  return [result, true];
 }
 
 export function isWrapped<T>(obj: T, key: string | symbol): obj is Wrapped<T> {


### PR DESCRIPTION
Stacked on #94 (sibling of #95 — no file overlap). Retarget to main after #94 merges.

- **P5**: `unmarshalProperties` now gets a VM-computed presence/value bitmask per property (one `getNumber` + at most one `getProp` for the present value/get/set entry) instead of six `getProp` + six `typeof`; descriptor semantics preserved exactly (bit layout documented in the source).
- **P6**: `marshalProperties` fast-paths plain data properties (string key, enumerable/writable/configurable all true, default-prototype target) via a single `ctx.setProp`, and lazily creates the descriptor aggregate so plain objects/arrays skip `Object.defineProperties` entirely. Fast path is restricted to default-prototype objects because `ctx.setProp` uses `[[Set]]` semantics, which would walk a custom prototype chain (e.g. class instances) and write to inherited setters/shared prototypes; `__proto__` keys are also excluded.

Benchmarks (median of 3, same machine, on top of #94): A. eval+unmarshal 528 → ~700-750 ops/s (+33-42%, verified independently at 749); B flat in the noisy sync-enabled bench, but isolated sync-disabled marshal measured ~37k → 58k ops/s (+55%); C/D/E/F flat within noise.

Verification: 172 tests / typecheck / lint pass; leak, identity, wrapper, and properties tests unchanged.