### PR TITLE
feat: asyncified host functions (asyncify option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ type Options = {
    * "Passing objects by reference" below.
    */
   marshalByReference?: (target: any) => boolean;
+
+  /**
+   * Marshal selected async host functions as *asyncified* functions, so the VM
+   * suspends until the host promise settles and the guest receives the resolved
+   * value synchronously. Only effective with an `AsyncArena`. See "Asyncified
+   * host functions" below.
+   */
+  asyncify?: boolean | ((target: (...args: any[]) => any) => boolean);
 };
 ```
 
@@ -371,6 +379,40 @@ ctx.dispose();
 #### `evalCodeAsync<T = any>(code: string, filename?: string): Promise<T>`
 
 Evaluate JS code asynchronously and return the result on the host. Like `evalCode`, it converts and re-throws errors thrown during evaluation.
+
+#### Asyncified host functions
+
+Normally an async host function is marshalled like any other function, so the guest receives a marshalled `Promise`:
+
+```js
+const ctx = await newAsyncContext();
+const arena = new AsyncArena(ctx, { isMarshalable: true });
+
+arena.expose({ fetchSync: async () => "result" });
+await arena.evalCodeAsync(`typeof fetchSync()`); // "object" (a Promise)
+```
+
+With the `asyncify` option, selected async functions are marshalled through QuickJS's [Asyncify](https://emscripten.org/docs/porting/asyncify.html) support instead. When the guest calls one, the VM suspends until the host promise settles and the guest receives the **resolved value synchronously**, as if the call were blocking:
+
+```js
+const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+arena.expose({ fetchSync: async () => "result" });
+await arena.evalCodeAsync(`const v = fetchSync(); typeof v`); // "string"
+await arena.evalCodeAsync(`fetchSync()`); // "result"
+```
+
+`asyncify` accepts:
+
+- `true` — asyncify every host function that is *declared* async, auto-detected via `Object.prototype.toString.call(fn) === "[object AsyncFunction]"`. Functions transpiled to ES5 (e.g. Babel/TypeScript targeting older runtimes) are plain functions that return a promise and are **not** detected — use the predicate form for those.
+- `(target) => boolean` — asyncify exactly the functions for which it returns `true`. Called with the unwrapped target, like `isMarshalable`.
+- absent / `false` — current behavior; async functions yield a `Promise` in the guest.
+
+Constraints (imposed by Emscripten Asyncify):
+
+- Asyncified functions only work when evaluation is entered through an async entry point (`evalCodeAsync`). Calling one during a synchronous `evalCode` throws `Error: Function unexpectedly returned a Promise`.
+- Only **one** suspended call is allowed at a time. Concurrent suspension (e.g. two asyncified calls awaiting simultaneously) throws a runtime error from quickjs-emscripten. Sequential calls are fine.
+- The option requires a `QuickJSAsyncContext` (from `newAsyncContext()`). On a plain synchronous context it is silently ignored and async functions behave as before (Promise).
 
 ### `defaultRegisteredObjects: [any, string][]`
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1255,6 +1255,149 @@ describe("AsyncArena", () => {
   });
 });
 
+describe("asyncify (#32)", () => {
+  test("without the option an async fn yields a Promise in the guest", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true });
+
+    arena.expose({ f: async () => "result" });
+    expect(await arena.evalCodeAsync(`typeof f()`)).toBe("object");
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("asyncify: true resolves the value synchronously in the guest", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({
+      f: async () => {
+        await new Promise(r => setTimeout(r, 1));
+        return "result";
+      },
+      g: async () => ({ a: 1, b: [2, 3] }),
+    });
+
+    expect(await arena.evalCodeAsync(`typeof f()`)).toBe("string");
+    expect(await arena.evalCodeAsync(`f()`)).toBe("result");
+    expect(await arena.evalCodeAsync(`const o = g(); [typeof o, o.a, o.b[1]]`)).toEqual([
+      "object",
+      1,
+      3,
+    ]);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("asyncify: true passes arguments through", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({ add: async (a: number, b: number) => a + b });
+    expect(await arena.evalCodeAsync(`add(2, 3)`)).toBe(5);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("predicate form only asyncifies matching functions", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, {
+      isMarshalable: true,
+      asyncify: target => (target as any).asyncified === true,
+    });
+
+    const yes = async () => "sync-value";
+    (yes as any).asyncified = true;
+    const no = async () => "promise-value";
+
+    arena.expose({ yes, no });
+
+    expect(await arena.evalCodeAsync(`typeof yes()`)).toBe("string");
+    expect(await arena.evalCodeAsync(`yes()`)).toBe("sync-value");
+    expect(await arena.evalCodeAsync(`typeof no()`)).toBe("object");
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("a rejecting asyncified fn surfaces as a catchable VM error", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({
+      boom: async () => {
+        throw new Error("kaboom");
+      },
+    });
+
+    // Uncaught in the guest: the error propagates back to the host.
+    await expect(arena.evalCodeAsync(`boom()`)).rejects.toThrow("kaboom");
+
+    // Caught in the guest: the guest can handle it synchronously.
+    expect(
+      await arena.evalCodeAsync(`
+        try {
+          boom();
+          "no-throw";
+        } catch (e) {
+          "caught:" + e.message;
+        }
+      `),
+    ).toBe("caught:kaboom");
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("sequential asyncified calls in one evalCodeAsync work", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({
+      first: async () => 10,
+      second: async (n: number) => n + 5,
+    });
+
+    expect(await arena.evalCodeAsync(`const a = first(); const b = second(a); a + b`)).toBe(25);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("calling an asyncified fn during synchronous evalCode fails", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({ f: async () => "result" });
+
+    // Asyncify can only suspend through an async entry point; a synchronous
+    // evalCode cannot unwind the stack, so it throws.
+    expect(() => arena.evalCode(`f()`)).toThrow("Function unexpectedly returned a Promise");
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("sync context fallback: asyncify does not break, async fn behaves as today", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({ f: async () => "result" });
+    // No newAsyncifiedFunction on a plain context: falls back to Promise marshalling.
+    expect(arena.evalCode(`globalThis.__p = f(); typeof __p`)).toBe("object");
+    // Let the host promise settle into the VM promise before disposing, so the
+    // marshalled resolution does not touch a disposed context.
+    await new Promise(r => setTimeout(r));
+    arena.executePendingJobs();
+
+    arena.dispose();
+    ctx.dispose();
+  });
+});
+
 describe("Symbol.dispose", () => {
   test("using disposes the arena", async () => {
     const ctx = (await getQuickJS()).newContext();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -318,6 +318,36 @@ describe("evalCode", () => {
     arena.dispose();
     ctx.dispose();
   });
+
+  test("options are forwarded (strict mode)", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    // Assigning to an undeclared variable succeeds in sloppy mode...
+    expect(arena.evalCode("x = 1")).toBe(1);
+    // ...but throws a ReferenceError in strict mode.
+    expect(() => arena.evalCode("y = 1", undefined, { strict: true })).toThrow(ReferenceError);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("filename appears in error stacks", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    try {
+      arena.evalCode(`throw new Error("boom")`, "my-special-file.js");
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect((e as Error).message).toBe("boom");
+      expect((e as Error).stack).toContain("my-special-file.js");
+    }
+
+    arena.dispose();
+    ctx.dispose();
+  });
 });
 
 describe("expose without sync", () => {
@@ -900,6 +930,30 @@ describe("evalModule", () => {
     arena.dispose();
     ctx.dispose();
   });
+
+  test("user options are merged and type is forced to module", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    // `strict` is passed through, and a user-supplied `type` is overridden with
+    // "module" so `export` still works and the exports are returned.
+    const exports = arena.evalModule(
+      `
+      export const value = 42;
+      export function greet(name) {
+        return "Hi, " + name;
+      }
+    `,
+      "with-options.js",
+      { strict: true, type: "global" },
+    );
+
+    expect(exports.value).toBe(42);
+    expect(exports.greet("World")).toBe("Hi, World");
+
+    arena.dispose();
+    ctx.dispose();
+  });
 });
 
 describe("memory management", () => {
@@ -1095,6 +1149,27 @@ describe("memory management", () => {
         }
       `);
     }).toThrow();
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("setInterruptHandler interrupts infinite loops", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    // Interrupt after the handler has been called a number of times.
+    let calls = 0;
+    arena.setInterruptHandler(() => ++calls > 1000);
+
+    expect(() => {
+      arena.evalCode(`while (true) {}`);
+    }).toThrow();
+    expect(calls).toBeGreaterThan(1000);
+
+    // After removing the handler, normal evaluation works again.
+    arena.removeInterruptHandler();
+    expect(arena.evalCode(`1 + 2`)).toBe(3);
 
     arena.dispose();
     ctx.dispose();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,6 +73,70 @@ describe("readme", () => {
   });
 });
 
+describe("class constructors (#92)", () => {
+  test("new on an exposed class inside the VM", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      hoge = "";
+
+      constructor() {
+        this.hoge = "foo";
+      }
+    }
+    arena.expose({ Cls });
+
+    const instance = arena.evalCode(`new Cls()`) as { hoge: string };
+    expect(instance.hoge).toBe("foo");
+    expect(arena.evalCode(`new Cls() instanceof Cls`)).toBe(true);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("constructor arguments reach the host", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      value: number;
+
+      constructor(a: number, b: number) {
+        this.value = a + b;
+      }
+    }
+    arena.expose({ Cls });
+
+    const instance = arena.evalCode(`new Cls(2, 3)`) as { value: number };
+    expect(instance.value).toBe(5);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("new on a synced class inside the VM", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true });
+
+    class Cls {
+      hoge = "";
+
+      constructor(v = "foo") {
+        this.hoge = v;
+      }
+    }
+    arena.expose({ Cls: arena.sync(Cls) });
+
+    const instance = arena.evalCode(`new Cls("bar")`) as { hoge: string };
+    expect(instance.hoge).toBe("bar");
+    expect(arena.evalCode(`new Cls() instanceof Cls`)).toBe(true);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+});
+
 describe("evalCode", () => {
   test("simple object and function", async () => {
     const ctx = (await getQuickJS()).newContext();

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,34 @@ export type Options = {
   syncEnabled?: boolean;
   /** A callback that returns whether an object should be passed to the VM by reference (as an opaque HostRef) instead of being marshalled by value/proxy. The guest cannot read such objects, but can hold them and pass them back to the host, where they resolve to the original object. */
   marshalByReference?: (target: any) => boolean;
+  /**
+   * Marshal selected host functions as *asyncified* functions. Normally an async
+   * host function is marshalled like any other function, so the guest receives a
+   * marshalled `Promise`. When a function is asyncified, the QuickJS VM instead
+   * suspends until the host promise settles and the guest receives the resolved
+   * value synchronously (as if the call were blocking).
+   *
+   * - `true`: asyncify every host function that is *declared* async, auto-detected
+   *   via `Object.prototype.toString.call(fn) === "[object AsyncFunction]"`. Note
+   *   that functions transpiled to ES5 (e.g. by Babel/TypeScript targeting older
+   *   runtimes) are plain functions returning a promise and are **not** detected —
+   *   use the predicate form for those.
+   * - predicate: asyncify exactly the functions for which it returns `true`. It is
+   *   called with the *unwrapped* target (the original function, not a sync proxy),
+   *   like `isMarshalable`.
+   * - absent/`false`: current behavior; async functions yield a `Promise` in the guest.
+   *
+   * Constraints (Emscripten Asyncify):
+   * - Asyncified functions only work when evaluation is entered through an async
+   *   entry point ({@link AsyncArena.evalCodeAsync}). Calling one during a
+   *   synchronous `evalCode` fails with `Error: Function unexpectedly returned a Promise`.
+   * - Only ONE suspended call is allowed at a time; concurrent suspension throws a
+   *   runtime error from quickjs-emscripten.
+   * - If the context does not support `newAsyncifiedFunction` (a plain sync context
+   *   from `getQuickJS().newContext()`), this option is silently ignored and async
+   *   functions behave as today (Promise).
+   */
+  asyncify?: boolean | ((target: (...args: any[]) => any) => boolean);
 };
 
 /**
@@ -479,6 +507,15 @@ export class Arena {
     return !!this._options?.marshalByReference?.(this._unwrap(t));
   };
 
+  _asyncify = (t: unknown): boolean => {
+    const a = this._options?.asyncify;
+    if (!a) return false;
+    const target = this._unwrap(t);
+    if (typeof a === "function") return typeof target === "function" && a(target as any);
+    // `a === true`: auto-detect functions declared with `async`.
+    return Object.prototype.toString.call(target) === "[object AsyncFunction]";
+  };
+
   // Register an opaque HostRef handle by its host value without wrapping it.
   _registerHostRef = (t: unknown, handle: QuickJSHandle): QuickJSHandle => {
     const u = this._unwrap(t);
@@ -564,6 +601,7 @@ export class Arena {
       preApply: this._marshalPreApply,
       prepareReturn: this._prepareMarshalReturn,
       unwrap: t => this._unwrap(t),
+      asyncify: this._options?.asyncify ? this._asyncify : undefined,
       custom: this._options?.customMarshaller,
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import type {
   SuccessOrFail,
   VmCallResult,
   Intrinsics,
+  ContextEvalOptions,
+  InterruptHandler,
 } from "quickjs-emscripten";
 
 import { wrapContext, QuickJSContextEx } from "./contextex";
@@ -44,7 +46,7 @@ export {
   consumeAll,
 };
 
-export type { Intrinsics };
+export type { Intrinsics, ContextEvalOptions, InterruptHandler };
 
 export type Options = {
   /** A callback that returns a boolean value that determines whether an object is marshalled or not. If false, no marshaling will be done and undefined will be passed to the QuickJS VM, otherwise marshaling will be done. By default, all objects will be marshalled. */
@@ -148,9 +150,15 @@ export class Arena {
 
   /**
    * Evaluate JS code in the VM and get the result as an object on the host side. It also converts and re-throws error objects when an error is thrown during evaluation.
+   *
+   * @param code - The JS code to evaluate
+   * @param filename - Optional filename used in error stacks and for debugging
+   * @param options - Optional eval options forwarded to quickjs-emscripten's
+   *   `evalCode`, either an `EvalFlags` bitmask (`number`) or a
+   *   {@link ContextEvalOptions} object (e.g. `{ strict: true }`)
    */
-  evalCode<T = any>(code: string): T {
-    const handle = this.context.evalCode(code);
+  evalCode<T = any>(code: string, filename?: string, options?: number | ContextEvalOptions): T {
+    const handle = this.context.evalCode(code, filename, options);
     return this._unwrapResultAndUnmarshal(handle);
   }
 
@@ -161,6 +169,10 @@ export class Arena {
    *
    * @param code - The ES module code to evaluate
    * @param filename - Optional filename for debugging purposes (default: "module.js")
+   * @param options - Optional {@link ContextEvalOptions}. `type` is always forced
+   *   to `"module"`, so any `type` in `options` is overridden. A numeric
+   *   `EvalFlags` bitmask cannot be merged with the forced module type and is
+   *   therefore not supported here; if a number is passed it is ignored.
    * @returns The module's exports object, or a Promise resolving to exports if using top-level await
    *
    * @example
@@ -186,8 +198,15 @@ export class Arena {
    * console.log(exports.data); // 123
    * ```
    */
-  evalModule<T = any>(code: string, filename = "module.js"): T | Promise<T> {
-    const handle = this.context.evalCode(code, filename, { type: "module" });
+  evalModule<T = any>(
+    code: string,
+    filename = "module.js",
+    options?: number | ContextEvalOptions,
+  ): T | Promise<T> {
+    const handle = this.context.evalCode(code, filename, {
+      ...(typeof options === "number" ? {} : options),
+      type: "module",
+    });
     return this._unwrapResultAndUnmarshal(handle);
   }
 
@@ -248,6 +267,45 @@ export class Arena {
    */
   setMaxStackSize(stackSize: number): void {
     this.context.runtime.setMaxStackSize(stackSize);
+  }
+
+  /**
+   * Set a callback which is regularly called by the QuickJS engine when it is
+   * executing code. This callback can be used to implement an execution
+   * timeout: return `true` from the handler to interrupt the running code.
+   *
+   * This is useful for preventing runaway CPU usage (e.g. infinite loops) in
+   * untrusted code.
+   *
+   * @param cb - The interrupt handler. Return `true` to interrupt execution.
+   *
+   * @example
+   * ```js
+   * // Interrupt evaluation after 1 second
+   * const deadline = Date.now() + 1000;
+   * arena.setInterruptHandler(() => Date.now() > deadline);
+   *
+   * try {
+   *   arena.evalCode(`while (true) {}`);
+   * } catch (e) {
+   *   console.log("Execution interrupted");
+   * }
+   * ```
+   */
+  setInterruptHandler(cb: InterruptHandler): void {
+    this.context.runtime.setInterruptHandler(cb);
+  }
+
+  /**
+   * Remove the interrupt handler previously set with `setInterruptHandler`.
+   *
+   * @example
+   * ```js
+   * arena.removeInterruptHandler();
+   * ```
+   */
+  removeInterruptHandler(): void {
+    this.context.runtime.removeInterruptHandler();
   }
 
   /**
@@ -661,9 +719,19 @@ export class AsyncArena extends Arena {
    * Evaluate JS code asynchronously in the VM and get the result on the host
    * side. Like `evalCode`, it converts and re-throws errors thrown during
    * evaluation. Use this when the code awaits host-provided promises.
+   *
+   * @param code - The JS code to evaluate
+   * @param filename - Optional filename used in error stacks and for debugging
+   * @param options - Optional eval options forwarded to quickjs-emscripten's
+   *   `evalCodeAsync`, either an `EvalFlags` bitmask (`number`) or a
+   *   {@link ContextEvalOptions} object (e.g. `{ strict: true }`)
    */
-  async evalCodeAsync<T = any>(code: string, filename?: string): Promise<T> {
-    const result = await this.asyncContext.evalCodeAsync(code, filename);
+  async evalCodeAsync<T = any>(
+    code: string,
+    filename?: string,
+    options?: number | ContextEvalOptions,
+  ): Promise<T> {
+    const result = await this.asyncContext.evalCodeAsync(code, filename, options);
     return this._unwrapResultAndUnmarshal(result);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,6 +491,7 @@ export class Arena {
       disposeTransient: this._disposeTransient,
       preApply: this._marshalPreApply,
       prepareReturn: this._prepareMarshalReturn,
+      unwrap: t => this._unwrap(t),
       custom: this._options?.customMarshaller,
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { defaultRegisteredObjects } from "./default";
 import marshal from "./marshal";
 import unmarshal from "./unmarshal";
 import unmarshalHostRef from "./unmarshal/hostref";
+import unmarshalPrimitive from "./unmarshal/primitive";
 import { complexity, isES2015Class, isObject, walkObject } from "./util";
 import VMMap from "./vmmap";
 import {
@@ -523,6 +524,14 @@ export class Arena {
   };
 
   _unmarshal = (handle: QuickJSHandle): any => {
+    // Primitives (undefined/number/string/boolean/bigint/null) are resolved by a
+    // cheap host-side `ctx.typeof`, skipping the `_registeredMap` VM lookup,
+    // HostRef resolution, and `_wrapHandle`. The VMMap only ever keys objects and
+    // symbols, so a primitive handle can never match `getByHandle`; symbols fall
+    // through `unmarshalPrimitive` and still reach the lookup below.
+    const [primitive, ok] = unmarshalPrimitive(this.context, handle);
+    if (ok) return primitive;
+
     const registered = this._registeredMap.getByHandle(handle);
     if (typeof registered !== "undefined") {
       return registered;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
   enableFnCache,
   disposeFnCache,
 } from "./vmutil";
-import { wrap, wrapHandle, unwrap, unwrapHandle, Wrapped } from "./wrapper";
+import { wrap, createWrapHandle, unwrap, unwrapHandle, Wrapped, WrapHandle } from "./wrapper";
 
 export {
   VMMap,
@@ -92,6 +92,7 @@ export class Arena {
   _temporalSync = new Set<any>();
   _symbol = Symbol();
   _symbolHandle: QuickJSHandle;
+  _wrapHandleImpl: WrapHandle;
   _options?: Options;
 
   /** Constructs a new Arena instance. It requires a quickjs-emscripten context initialized with `quickjs.newContext()`. */
@@ -108,6 +109,17 @@ export class Arena {
     enableFnCache(this.context);
     this._options = options;
     this._symbolHandle = ctx.unwrapResult(ctx.evalCode(`Symbol()`));
+    // One proxyFuncs handle shared by every wrapped handle for the Arena's
+    // lifetime, instead of allocating a fresh VM function per wrap.
+    this._wrapHandleImpl = createWrapHandle(
+      this.context,
+      this._symbol,
+      this._symbolHandle,
+      this._unmarshal,
+      this._syncMode,
+      this._options?.isHandleWrappable,
+      this._options?.syncEnabled ?? true,
+    );
     this._map = new VMMap(ctx);
     this._registeredMap = new VMMap(ctx);
     this.registerAll(options?.registeredObjects ?? defaultRegisteredObjects);
@@ -123,6 +135,7 @@ export class Arena {
     this._transientHandles.clear();
     this._map.dispose();
     this._registeredMap.dispose();
+    this._wrapHandleImpl.dispose();
     this._symbolHandle.dispose();
     disposeFnCache(this.context);
     this.context.disposeEx?.();
@@ -622,16 +635,7 @@ export class Arena {
   };
 
   _wrapHandle(handle: QuickJSHandle): [Wrapped<QuickJSHandle> | undefined, boolean] {
-    return wrapHandle(
-      this.context,
-      handle,
-      this._symbol,
-      this._symbolHandle,
-      this._unmarshal,
-      this._syncMode,
-      this._options?.isHandleWrappable,
-      this._options?.syncEnabled ?? true,
-    );
+    return this._wrapHandleImpl.wrapHandle(handle);
   }
 
   _unwrapHandle(target: QuickJSHandle): [QuickJSHandle, boolean] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,7 +501,11 @@ export class Arena {
     this._transientHandles.delete(handle);
 
     const syncEnabled = this._options?.syncEnabled ?? true;
-    return [handle, !syncEnabled || !this._map.hasHandle(handle)];
+    // A non-object (primitive) handle is never retained in `_map` (registered
+    // primitives already returned above via `_registeredMap`), so skip the
+    // `hasHandle` VM roundtrip and mark it disposable directly.
+    if (!syncEnabled || !isObject(target)) return [handle, true];
+    return [handle, !this._map.hasHandle(handle)];
   };
 
   _prepareMarshalReturn = (h: QuickJSHandle): QuickJSHandle => {
@@ -512,7 +516,12 @@ export class Arena {
     // `x === fn()` identity across calls. Hand the VM a dup instead and keep
     // ours alive. With sync off, handles are not retained, so this is a no-op.
     const syncEnabled = this._options?.syncEnabled ?? true;
-    return syncEnabled && h.alive && this._map.hasHandle(h) ? h.dup() : h;
+    // Only object handles are retained in `_map`; a primitive return can never
+    // be in the map, so `isHandleObject` (a cheap typeof) skips the `hasHandle`
+    // VM roundtrip for primitive returns from host functions.
+    return syncEnabled && h.alive && isHandleObject(this.context, h) && this._map.hasHandle(h)
+      ? h.dup()
+      : h;
   };
 
   _preUnmarshal = (t: any, h: QuickJSHandle): Wrapped<any> => {

--- a/src/marshal/function.ts
+++ b/src/marshal/function.ts
@@ -14,8 +14,15 @@ export default function marshalFunction(
   preApply?: (target: (...args: any[]) => any, thisArg: unknown, args: unknown[]) => any,
   disposeTransient: (handle: QuickJSHandle) => void = () => {},
   prepareReturn: (handle: QuickJSHandle) => QuickJSHandle = h => h,
+  unwrap: (target: unknown) => unknown = t => t,
 ): QuickJSHandle | undefined {
   if (typeof target !== "function") return;
+
+  // `target` may be a host-side proxy wrapper; unwrap it before the class check,
+  // because Function.prototype.toString on a callable proxy never matches /^class/.
+  // Computed once here rather than per call to avoid the toString + regex on every
+  // VM→host invocation.
+  const isClass = isES2015Class(unwrap(target));
 
   const raw = ctx
     .newFunction(target.name, function (...argHandles) {
@@ -29,9 +36,9 @@ export default function marshalFunction(
       const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
       const args = argHandles.map(a => unmarshal(a));
 
-      if (isES2015Class(target) && isObject(that)) {
+      if (isClass && isObject(that)) {
         // Class constructors cannot be invoked without new expression, and new.target is not changed
-        const result = new target(...args);
+        const result = new (target as new (...args: any[]) => any)(...args);
         Object.entries(result).forEach(([key, value]) => {
           const valueHandle = marshal(value);
           ctx.setProp(this, key, valueHandle);

--- a/src/marshal/function.ts
+++ b/src/marshal/function.ts
@@ -1,4 +1,4 @@
-import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
+import type { QuickJSAsyncContext, QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
 
 import { isES2015Class, isObject } from "../util";
 import { call } from "../vmutil";
@@ -15,6 +15,7 @@ export default function marshalFunction(
   disposeTransient: (handle: QuickJSHandle) => void = () => {},
   prepareReturn: (handle: QuickJSHandle) => QuickJSHandle = h => h,
   unwrap: (target: unknown) => unknown = t => t,
+  asyncify?: (target: unknown) => boolean,
 ): QuickJSHandle | undefined {
   if (typeof target !== "function") return;
 
@@ -22,43 +23,74 @@ export default function marshalFunction(
   // because Function.prototype.toString on a callable proxy never matches /^class/.
   // Computed once here rather than per call to avoid the toString + regex on every
   // VM→host invocation.
-  const isClass = isES2015Class(unwrap(target));
+  const unwrapped = unwrap(target);
+  const isClass = isES2015Class(unwrapped);
 
-  const raw = ctx
-    .newFunction(target.name, function (...argHandles) {
-      // A plain call (`fn()`) passes the VM global object as `this`. Unmarshalling
-      // it would eagerly deep-copy the entire global graph (hundreds of handles)
-      // on the first call, for a `this` host functions almost never use — and
-      // leaking globalThis to the host is undesirable. So global `this` is passed
-      // to the host function as `undefined`, which differs from plain JS where a
-      // non-strict function sees `this === globalThis` (see README Limitations).
-      // Real method calls still get their receiver unmarshalled.
-      const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
-      const args = argHandles.map(a => unmarshal(a));
+  // Marshal as an Asyncified function only when the caller opts in for this
+  // target AND the context actually supports it (a plain sync context has no
+  // `newAsyncifiedFunction`, so fall back to the normal function marshalling,
+  // which hands the guest a marshalled Promise as before).
+  const useAsyncify =
+    !!asyncify && asyncify(unwrapped) && "newAsyncifiedFunction" in ctx;
 
-      if (isClass && isObject(that)) {
-        // Class constructors cannot be invoked without new expression, and new.target is not changed
-        const result = new (target as new (...args: any[]) => any)(...args);
-        Object.entries(result).forEach(([key, value]) => {
-          const valueHandle = marshal(value);
-          ctx.setProp(this, key, valueHandle);
-          // setProp dup'd the value into `this`; drop ours if it was transient.
-          disposeTransient(valueHandle);
-        });
-        return this;
-      }
+  const raw = (
+    useAsyncify
+      ? // Asyncify: the VM stack is suspended until the host promise settles, so
+        // the guest receives the resolved value synchronously. Async functions
+        // can never be class constructors, so the class-constructor path is
+        // skipped here.
+        (ctx as QuickJSAsyncContext).newAsyncifiedFunction(target.name, async function (
+          ...argHandles
+        ) {
+          const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
+          const args = argHandles.map(a => unmarshal(a));
 
-      // The VM disposes whatever we return here. `prepareReturn` dups the
-      // handle when the VMMap retains it, so the map keeps a live copy and
-      // identity (`x === fn()` across calls) survives instead of going stale.
-      return prepareReturn(
-        marshal(
-          preApply
+          // `preApply` wraps the (synchronous) invocation to toggle temporal sync
+          // around it; it returns the host promise, which we await here. Note that
+          // its finally runs as soon as `apply` returns the promise, so temporal
+          // sync is only active for the synchronous portion of the async function,
+          // not across its awaits.
+          const result = await (preApply
             ? preApply(target as (...args: any[]) => any, that, args)
-            : (target as (...args: any[]) => any).apply(that, args),
-        ),
-      );
-    })
+            : (target as (...args: any[]) => any).apply(that, args));
+
+          return prepareReturn(marshal(result));
+        })
+      : ctx.newFunction(target.name, function (...argHandles) {
+          // A plain call (`fn()`) passes the VM global object as `this`. Unmarshalling
+          // it would eagerly deep-copy the entire global graph (hundreds of handles)
+          // on the first call, for a `this` host functions almost never use — and
+          // leaking globalThis to the host is undesirable. So global `this` is passed
+          // to the host function as `undefined`, which differs from plain JS where a
+          // non-strict function sees `this === globalThis` (see README Limitations).
+          // Real method calls still get their receiver unmarshalled.
+          const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
+          const args = argHandles.map(a => unmarshal(a));
+
+          if (isClass && isObject(that)) {
+            // Class constructors cannot be invoked without new expression, and new.target is not changed
+            const result = new (target as new (...args: any[]) => any)(...args);
+            Object.entries(result).forEach(([key, value]) => {
+              const valueHandle = marshal(value);
+              ctx.setProp(this, key, valueHandle);
+              // setProp dup'd the value into `this`; drop ours if it was transient.
+              disposeTransient(valueHandle);
+            });
+            return this;
+          }
+
+          // The VM disposes whatever we return here. `prepareReturn` dups the
+          // handle when the VMMap retains it, so the map keeps a live copy and
+          // identity (`x === fn()` across calls) survives instead of going stale.
+          return prepareReturn(
+            marshal(
+              preApply
+                ? preApply(target as (...args: any[]) => any, that, args)
+                : (target as (...args: any[]) => any).apply(that, args),
+            ),
+          );
+        })
+  )
     .consume(handle2 =>
       // fucntions created by vm.newFunction are not callable as a class constrcutor
       call(

--- a/src/marshal/index.ts
+++ b/src/marshal/index.ts
@@ -36,6 +36,11 @@ export type Options = {
   // Strip a host-side proxy wrapper from a target. Used to detect a wrapped class
   // constructor, which would otherwise be hidden behind the proxy. Defaults to identity.
   unwrap?: (target: unknown) => unknown;
+  // Decide whether a host function should be marshalled as an Asyncified function
+  // (the VM suspends until the host promise settles, so the guest gets the
+  // resolved value synchronously). Called with the unwrapped target. Only takes
+  // effect when the context supports `newAsyncifiedFunction`.
+  asyncify?: (target: unknown) => boolean;
   custom?: Iterable<(obj: unknown, ctx: QuickJSContext) => QuickJSHandle | undefined>;
 };
 
@@ -91,6 +96,7 @@ export function marshal(target: unknown, options: Options): QuickJSHandle {
       disposeTransient,
       options.prepareReturn,
       options.unwrap,
+      options.asyncify,
     ) ??
     marshalMapSet(ctx, target, marshal2, pre2, disposeTransient) ??
     marshalObject(ctx, target, marshal2, pre2, disposeTransient) ??

--- a/src/marshal/index.ts
+++ b/src/marshal/index.ts
@@ -33,6 +33,9 @@ export type Options = {
   // the VMMap retains (for identity, while sync is on) must be dup'd here or its
   // map entry goes stale. Defaults to identity (no-op).
   prepareReturn?: (handle: QuickJSHandle) => QuickJSHandle;
+  // Strip a host-side proxy wrapper from a target. Used to detect a wrapped class
+  // constructor, which would otherwise be hidden behind the proxy. Defaults to identity.
+  unwrap?: (target: unknown) => unknown;
   custom?: Iterable<(obj: unknown, ctx: QuickJSContext) => QuickJSHandle | undefined>;
 };
 
@@ -87,6 +90,7 @@ export function marshal(target: unknown, options: Options): QuickJSHandle {
       options.preApply,
       disposeTransient,
       options.prepareReturn,
+      options.unwrap,
     ) ??
     marshalMapSet(ctx, target, marshal2, pre2, disposeTransient) ??
     marshalObject(ctx, target, marshal2, pre2, disposeTransient) ??

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,7 +1,7 @@
 import type { QuickJSHandle, QuickJSContext } from "quickjs-emscripten";
 
 import { isObject } from "./util";
-import { call, consume, isHandleObject, mayConsumeAll } from "./vmutil";
+import { call, isHandleObject, mayConsumeAll } from "./vmutil";
 
 export type SyncMode = "both" | "vm" | "host";
 
@@ -113,23 +113,34 @@ export function wrap<T = any>(
   return rec;
 }
 
-export function wrapHandle(
+export type WrapHandle = {
+  /** Wrap a VM handle with the shared proxyFuncs, like the old `wrapHandle`. */
+  wrapHandle: (handle: QuickJSHandle) => [Wrapped<QuickJSHandle> | undefined, boolean];
+  /** Dispose the shared proxyFuncs handle. Call exactly once, at Arena dispose. */
+  dispose: () => void;
+};
+
+/**
+ * Build a `wrapHandle` function that shares ONE `proxyFuncs` handle across every
+ * handle it wraps, instead of allocating a fresh VM function per wrapped object.
+ *
+ * The callbacks inside proxyFuncs (getSyncMode/setter/deleter/definer) receive
+ * the target handle as an argument, so the closure only captures values stable
+ * for the whole Arena lifetime (`ctx`, `unmarshal`, `syncMode`, `proxyKeySymbol`).
+ * The proxyFuncs handle is created lazily on first use and must be disposed once
+ * via `dispose()`; the VM-side Proxy keeps its own reference to it, so it stays
+ * valid for every proxy created during the Arena's lifetime.
+ */
+export function createWrapHandle(
   ctx: QuickJSContext,
-  handle: QuickJSHandle,
   proxyKeySymbol: symbol,
   proxyKeySymbolHandle: QuickJSHandle,
   unmarshal: (handle: QuickJSHandle) => any,
   syncMode?: (target: QuickJSHandle) => SyncMode | undefined,
   wrappable?: (target: QuickJSHandle, ctx: QuickJSContext) => boolean,
   syncEnabled = true,
-): [Wrapped<QuickJSHandle> | undefined, boolean] {
-  if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
-    return [undefined, false];
-
-  if (isHandleWrapped(ctx, handle, proxyKeySymbolHandle)) return [handle, false];
-
-  // Sync globally disabled: skip the VM-side proxy.
-  if (!syncEnabled) return [handle as Wrapped<QuickJSHandle>, false];
+): WrapHandle {
+  let proxyFuncs: QuickJSHandle | undefined;
 
   const getSyncMode = (h: QuickJSHandle) => {
     const res = syncMode?.(unmarshal(h));
@@ -162,26 +173,43 @@ export function wrapHandle(
     Object.defineProperty(unwrap(target, proxyKeySymbol), key, desc);
   };
 
-  const proxyFuncs = ctx.newFunction("proxyFuncs", (t, ...args) => {
-    const name = ctx.getNumber(t);
-    switch (name) {
-      case 1:
-        return getSyncMode(args[0]);
-      case 2:
-        return setter(args[0], args[1], args[2]);
-      case 3:
-        return deleter(args[0], args[1]);
-      case 4:
-        return definer(args[0], args[1], args[2]);
-    }
-    return ctx.undefined;
-  });
-  // Use the exception-safe consume so proxyFuncs is disposed even if compiling
-  // the proxy below throws (e.g. under memory pressure).
-  return consume(proxyFuncs, proxyFuncs => [
-    call(
-      ctx,
-      `(target, sym, proxyFuncs) => {
+  const ensureProxyFuncs = (): QuickJSHandle => {
+    if (proxyFuncs && proxyFuncs.alive) return proxyFuncs;
+    proxyFuncs = ctx.newFunction("proxyFuncs", (t, ...args) => {
+      const name = ctx.getNumber(t);
+      switch (name) {
+        case 1:
+          return getSyncMode(args[0]);
+        case 2:
+          return setter(args[0], args[1], args[2]);
+        case 3:
+          return deleter(args[0], args[1]);
+        case 4:
+          return definer(args[0], args[1], args[2]);
+      }
+      return ctx.undefined;
+    });
+    return proxyFuncs;
+  };
+
+  const wrapHandleFn = (
+    handle: QuickJSHandle,
+  ): [Wrapped<QuickJSHandle> | undefined, boolean] => {
+    if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
+      return [undefined, false];
+
+    if (isHandleWrapped(ctx, handle, proxyKeySymbolHandle)) return [handle, false];
+
+    // Sync globally disabled: skip the VM-side proxy.
+    if (!syncEnabled) return [handle as Wrapped<QuickJSHandle>, false];
+
+    // The shared proxyFuncs is borrowed (not consumed) by `call`, and the
+    // VM-side Proxy keeps its own reference, so it stays alive for the whole
+    // Arena lifetime and is disposed once via `dispose()` even if `call` throws.
+    return [
+      call(
+        ctx,
+        `(target, sym, proxyFuncs) => {
           const rec =  new Proxy(target, {
             get(obj, key, receiver) {
               return key === sym ? obj : Reflect.get(obj, key, receiver)
@@ -219,13 +247,53 @@ export function wrapHandle(
           });
           return rec;
         }`,
-      undefined,
-      handle,
-      proxyKeySymbolHandle,
-      proxyFuncs,
-    ) as Wrapped<QuickJSHandle>,
-    true,
-  ]);
+        undefined,
+        handle,
+        proxyKeySymbolHandle,
+        ensureProxyFuncs(),
+      ) as Wrapped<QuickJSHandle>,
+      true,
+    ];
+  };
+
+  return {
+    wrapHandle: wrapHandleFn,
+    dispose: () => {
+      if (proxyFuncs && proxyFuncs.alive) proxyFuncs.dispose();
+      proxyFuncs = undefined;
+    },
+  };
+}
+
+/**
+ * Standalone wrap of a single handle. Builds a one-shot {@link createWrapHandle}
+ * and disposes its proxyFuncs right after; the VM-side Proxy keeps its own
+ * reference, so the wrapped handle stays valid.
+ */
+export function wrapHandle(
+  ctx: QuickJSContext,
+  handle: QuickJSHandle,
+  proxyKeySymbol: symbol,
+  proxyKeySymbolHandle: QuickJSHandle,
+  unmarshal: (handle: QuickJSHandle) => any,
+  syncMode?: (target: QuickJSHandle) => SyncMode | undefined,
+  wrappable?: (target: QuickJSHandle, ctx: QuickJSContext) => boolean,
+  syncEnabled = true,
+): [Wrapped<QuickJSHandle> | undefined, boolean] {
+  const w = createWrapHandle(
+    ctx,
+    proxyKeySymbol,
+    proxyKeySymbolHandle,
+    unmarshal,
+    syncMode,
+    wrappable,
+    syncEnabled,
+  );
+  try {
+    return w.wrapHandle(handle);
+  } finally {
+    w.dispose();
+  }
 }
 
 export function unwrap<T>(obj: T, key: string | symbol): T {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -198,18 +198,32 @@ export function createWrapHandle(
     if (!isHandleObject(ctx, handle) || (wrappable && !wrappable(handle, ctx)))
       return [undefined, false];
 
-    if (isHandleWrapped(ctx, handle, proxyKeySymbolHandle)) return [handle, false];
-
-    // Sync globally disabled: skip the VM-side proxy.
+    // Sync globally disabled: skip the VM-side proxy. (When wrapped or built-in
+    // the old path also returned `[handle, false]`, so this order is equivalent
+    // and avoids the extra check entirely.)
     if (!syncEnabled) return [handle as Wrapped<QuickJSHandle>, false];
 
+    // The "already wrapped / must-not-wrap built-in" test is folded into the
+    // proxy-creating VM call: it returns `null` when it declines (built-in with
+    // internal slots, or `target[sym]` already set), so we pay ONE roundtrip
+    // instead of a separate `isHandleWrapped` call plus the wrap. A declined
+    // handle is treated as already-wrapped by returning the ORIGINAL handle.
+    //
     // The shared proxyFuncs is borrowed (not consumed) by `call`, and the
     // VM-side Proxy keeps its own reference, so it stays alive for the whole
     // Arena lifetime and is disposed once via `dispose()` even if `call` throws.
-    return [
-      call(
-        ctx,
-        `(target, sym, proxyFuncs) => {
+    const result = call(
+      ctx,
+      `(target, sym, proxyFuncs) => {
+          if (
+            (target instanceof Promise) ||
+            (target instanceof Date) ||
+            (target instanceof ArrayBuffer) ||
+            (ArrayBuffer.isView(target)) ||
+            (target instanceof Map) ||
+            (target instanceof Set) ||
+            target[sym]
+          ) return null;
           const rec =  new Proxy(target, {
             get(obj, key, receiver) {
               return key === sym ? obj : Reflect.get(obj, key, receiver)
@@ -247,13 +261,21 @@ export function createWrapHandle(
           });
           return rec;
         }`,
-        undefined,
-        handle,
-        proxyKeySymbolHandle,
-        ensureProxyFuncs(),
-      ) as Wrapped<QuickJSHandle>,
-      true,
-    ];
+      undefined,
+      handle,
+      proxyKeySymbolHandle,
+      ensureProxyFuncs(),
+    );
+
+    // Declined: the VM function returned null. Detect it with cheap host-side
+    // checks (no callFunction), dispose the null result, and treat the original
+    // handle as already-wrapped.
+    if (ctx.sameValue(result, ctx.null)) {
+      result.dispose();
+      return [handle as Wrapped<QuickJSHandle>, false];
+    }
+
+    return [result as Wrapped<QuickJSHandle>, true];
   };
 
   return {
@@ -305,8 +327,22 @@ export function unwrapHandle(
   handle: QuickJSHandle,
   key: QuickJSHandle,
 ): [QuickJSHandle, boolean] {
-  if (!isHandleWrapped(ctx, handle, key)) return [handle, false];
-  return [ctx.getProp(handle, key), true];
+  // Fold the `isHandleWrapped` test and the property read into ONE VM call:
+  // return the unwrapped target (`a[sym]`) or null. This pays a single roundtrip
+  // instead of `isHandleWrapped` + `getProp`. A null result means "not wrapped",
+  // so the original handle is used as-is.
+  const result = call(
+    ctx,
+    `(a, s) => (typeof a === "object" && a !== null || typeof a === "function") && a[s] || null`,
+    undefined,
+    handle,
+    key,
+  );
+  if (ctx.sameValue(result, ctx.null)) {
+    result.dispose();
+    return [handle, false];
+  }
+  return [result, true];
 }
 
 export function isWrapped<T>(obj: T, key: string | symbol): obj is Wrapped<T> {


### PR DESCRIPTION
Stacked on #95 (→ #94 → #93); retarget as bases merge.

## Summary

Adds a new `asyncify` Arena option (`boolean | predicate`). When enabled on a `QuickJSAsyncContext` (AsyncArena), matching host functions are marshalled via `newAsyncifiedFunction`, so the guest receives the resolved value synchronously (the VM suspends until the host promise settles) instead of a marshalled Promise.

- `true` auto-detects declared async functions (`fn.toString() === "[object AsyncFunction]"`); transpiled async functions (e.g. via Babel/TS downleveling) are not detected this way and need the predicate form to opt in explicitly.
- Falls back silently to Promise marshalling on sync contexts, so the option is safe to leave set even when the arena isn't async.
- Asyncify suspension was verified to propagate correctly through the existing VM-side function wrapper, so the wrapper is kept for uniformity between sync and asyncified host functions.

## Constraints (documented in README)

1. Requires an async entry point — calling `evalCode` synchronously on code that triggers an asyncified host function fails with "Function unexpectedly returned a Promise"; use `evalCodeAsync` (or equivalent) instead.
2. Only one asyncify suspension can be in flight at a time (a fundamental Asyncify limitation), so concurrent asyncified calls are not supported.
3. Only applies to `QuickJSAsyncContext` / `AsyncArena` — on a sync context/arena the option is a no-op and functions marshal as Promises as before.

## Verification

184 tests / typecheck / lint all pass.

Closes #32