### PR TITLE
feat: asyncified host functions (asyncify option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ type Options = {
    * "Passing objects by reference" below.
    */
   marshalByReference?: (target: any) => boolean;
+
+  /**
+   * Marshal selected async host functions as *asyncified* functions, so the VM
+   * suspends until the host promise settles and the guest receives the resolved
+   * value synchronously. Only effective with an `AsyncArena`. See "Asyncified
+   * host functions" below.
+   */
+  asyncify?: boolean | ((target: (...args: any[]) => any) => boolean);
 };
 ```
 
@@ -371,6 +379,40 @@ ctx.dispose();
 #### `evalCodeAsync<T = any>(code: string, filename?: string): Promise<T>`
 
 Evaluate JS code asynchronously and return the result on the host. Like `evalCode`, it converts and re-throws errors thrown during evaluation.
+
+#### Asyncified host functions
+
+Normally an async host function is marshalled like any other function, so the guest receives a marshalled `Promise`:
+
+```js
+const ctx = await newAsyncContext();
+const arena = new AsyncArena(ctx, { isMarshalable: true });
+
+arena.expose({ fetchSync: async () => "result" });
+await arena.evalCodeAsync(`typeof fetchSync()`); // "object" (a Promise)
+```
+
+With the `asyncify` option, selected async functions are marshalled through QuickJS's [Asyncify](https://emscripten.org/docs/porting/asyncify.html) support instead. When the guest calls one, the VM suspends until the host promise settles and the guest receives the **resolved value synchronously**, as if the call were blocking:
+
+```js
+const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+arena.expose({ fetchSync: async () => "result" });
+await arena.evalCodeAsync(`const v = fetchSync(); typeof v`); // "string"
+await arena.evalCodeAsync(`fetchSync()`); // "result"
+```
+
+`asyncify` accepts:
+
+- `true` — asyncify every host function that is *declared* async, auto-detected via `Object.prototype.toString.call(fn) === "[object AsyncFunction]"`. Functions transpiled to ES5 (e.g. Babel/TypeScript targeting older runtimes) are plain functions that return a promise and are **not** detected — use the predicate form for those.
+- `(target) => boolean` — asyncify exactly the functions for which it returns `true`. Called with the unwrapped target, like `isMarshalable`.
+- absent / `false` — current behavior; async functions yield a `Promise` in the guest.
+
+Constraints (imposed by Emscripten Asyncify):
+
+- Asyncified functions only work when evaluation is entered through an async entry point (`evalCodeAsync`). Calling one during a synchronous `evalCode` throws `Error: Function unexpectedly returned a Promise`.
+- Only **one** suspended call is allowed at a time. Concurrent suspension (e.g. two asyncified calls awaiting simultaneously) throws a runtime error from quickjs-emscripten. Sequential calls are fine.
+- The option requires a `QuickJSAsyncContext` (from `newAsyncContext()`). On a plain synchronous context it is silently ignored and async functions behave as before (Promise).
 
 ### `defaultRegisteredObjects: [any, string][]`
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1255,6 +1255,149 @@ describe("AsyncArena", () => {
   });
 });
 
+describe("asyncify (#32)", () => {
+  test("without the option an async fn yields a Promise in the guest", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true });
+
+    arena.expose({ f: async () => "result" });
+    expect(await arena.evalCodeAsync(`typeof f()`)).toBe("object");
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("asyncify: true resolves the value synchronously in the guest", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({
+      f: async () => {
+        await new Promise(r => setTimeout(r, 1));
+        return "result";
+      },
+      g: async () => ({ a: 1, b: [2, 3] }),
+    });
+
+    expect(await arena.evalCodeAsync(`typeof f()`)).toBe("string");
+    expect(await arena.evalCodeAsync(`f()`)).toBe("result");
+    expect(await arena.evalCodeAsync(`const o = g(); [typeof o, o.a, o.b[1]]`)).toEqual([
+      "object",
+      1,
+      3,
+    ]);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("asyncify: true passes arguments through", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({ add: async (a: number, b: number) => a + b });
+    expect(await arena.evalCodeAsync(`add(2, 3)`)).toBe(5);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("predicate form only asyncifies matching functions", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, {
+      isMarshalable: true,
+      asyncify: target => (target as any).asyncified === true,
+    });
+
+    const yes = async () => "sync-value";
+    (yes as any).asyncified = true;
+    const no = async () => "promise-value";
+
+    arena.expose({ yes, no });
+
+    expect(await arena.evalCodeAsync(`typeof yes()`)).toBe("string");
+    expect(await arena.evalCodeAsync(`yes()`)).toBe("sync-value");
+    expect(await arena.evalCodeAsync(`typeof no()`)).toBe("object");
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("a rejecting asyncified fn surfaces as a catchable VM error", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({
+      boom: async () => {
+        throw new Error("kaboom");
+      },
+    });
+
+    // Uncaught in the guest: the error propagates back to the host.
+    await expect(arena.evalCodeAsync(`boom()`)).rejects.toThrow("kaboom");
+
+    // Caught in the guest: the guest can handle it synchronously.
+    expect(
+      await arena.evalCodeAsync(`
+        try {
+          boom();
+          "no-throw";
+        } catch (e) {
+          "caught:" + e.message;
+        }
+      `),
+    ).toBe("caught:kaboom");
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("sequential asyncified calls in one evalCodeAsync work", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({
+      first: async () => 10,
+      second: async (n: number) => n + 5,
+    });
+
+    expect(await arena.evalCodeAsync(`const a = first(); const b = second(a); a + b`)).toBe(25);
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("calling an asyncified fn during synchronous evalCode fails", async () => {
+    const ctx = await newAsyncContext();
+    const arena = new AsyncArena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({ f: async () => "result" });
+
+    // Asyncify can only suspend through an async entry point; a synchronous
+    // evalCode cannot unwind the stack, so it throws.
+    expect(() => arena.evalCode(`f()`)).toThrow("Function unexpectedly returned a Promise");
+
+    arena.dispose();
+    ctx.dispose();
+  });
+
+  test("sync context fallback: asyncify does not break, async fn behaves as today", async () => {
+    const ctx = (await getQuickJS()).newContext();
+    const arena = new Arena(ctx, { isMarshalable: true, asyncify: true });
+
+    arena.expose({ f: async () => "result" });
+    // No newAsyncifiedFunction on a plain context: falls back to Promise marshalling.
+    expect(arena.evalCode(`globalThis.__p = f(); typeof __p`)).toBe("object");
+    // Let the host promise settle into the VM promise before disposing, so the
+    // marshalled resolution does not touch a disposed context.
+    await new Promise(r => setTimeout(r));
+    arena.executePendingJobs();
+
+    arena.dispose();
+    ctx.dispose();
+  });
+});
+
 describe("Symbol.dispose", () => {
   test("using disposes the arena", async () => {
     const ctx = (await getQuickJS()).newContext();

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,34 @@ export type Options = {
   syncEnabled?: boolean;
   /** A callback that returns whether an object should be passed to the VM by reference (as an opaque HostRef) instead of being marshalled by value/proxy. The guest cannot read such objects, but can hold them and pass them back to the host, where they resolve to the original object. */
   marshalByReference?: (target: any) => boolean;
+  /**
+   * Marshal selected host functions as *asyncified* functions. Normally an async
+   * host function is marshalled like any other function, so the guest receives a
+   * marshalled `Promise`. When a function is asyncified, the QuickJS VM instead
+   * suspends until the host promise settles and the guest receives the resolved
+   * value synchronously (as if the call were blocking).
+   *
+   * - `true`: asyncify every host function that is *declared* async, auto-detected
+   *   via `Object.prototype.toString.call(fn) === "[object AsyncFunction]"`. Note
+   *   that functions transpiled to ES5 (e.g. by Babel/TypeScript targeting older
+   *   runtimes) are plain functions returning a promise and are **not** detected —
+   *   use the predicate form for those.
+   * - predicate: asyncify exactly the functions for which it returns `true`. It is
+   *   called with the *unwrapped* target (the original function, not a sync proxy),
+   *   like `isMarshalable`.
+   * - absent/`false`: current behavior; async functions yield a `Promise` in the guest.
+   *
+   * Constraints (Emscripten Asyncify):
+   * - Asyncified functions only work when evaluation is entered through an async
+   *   entry point ({@link AsyncArena.evalCodeAsync}). Calling one during a
+   *   synchronous `evalCode` fails with `Error: Function unexpectedly returned a Promise`.
+   * - Only ONE suspended call is allowed at a time; concurrent suspension throws a
+   *   runtime error from quickjs-emscripten.
+   * - If the context does not support `newAsyncifiedFunction` (a plain sync context
+   *   from `getQuickJS().newContext()`), this option is silently ignored and async
+   *   functions behave as today (Promise).
+   */
+  asyncify?: boolean | ((target: (...args: any[]) => any) => boolean);
 };
 
 /**
@@ -479,6 +507,15 @@ export class Arena {
     return !!this._options?.marshalByReference?.(this._unwrap(t));
   };
 
+  _asyncify = (t: unknown): boolean => {
+    const a = this._options?.asyncify;
+    if (!a) return false;
+    const target = this._unwrap(t);
+    if (typeof a === "function") return typeof target === "function" && a(target as any);
+    // `a === true`: auto-detect functions declared with `async`.
+    return Object.prototype.toString.call(target) === "[object AsyncFunction]";
+  };
+
   // Register an opaque HostRef handle by its host value without wrapping it.
   _registerHostRef = (t: unknown, handle: QuickJSHandle): QuickJSHandle => {
     const u = this._unwrap(t);
@@ -564,6 +601,7 @@ export class Arena {
       preApply: this._marshalPreApply,
       prepareReturn: this._prepareMarshalReturn,
       unwrap: t => this._unwrap(t),
+      asyncify: this._options?.asyncify ? this._asyncify : undefined,
       custom: this._options?.customMarshaller,
     });
 

--- a/src/marshal/function.ts
+++ b/src/marshal/function.ts
@@ -1,4 +1,4 @@
-import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
+import type { QuickJSAsyncContext, QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
 
 import { isES2015Class, isObject } from "../util";
 import { call } from "../vmutil";
@@ -15,6 +15,7 @@ export default function marshalFunction(
   disposeTransient: (handle: QuickJSHandle) => void = () => {},
   prepareReturn: (handle: QuickJSHandle) => QuickJSHandle = h => h,
   unwrap: (target: unknown) => unknown = t => t,
+  asyncify?: (target: unknown) => boolean,
 ): QuickJSHandle | undefined {
   if (typeof target !== "function") return;
 
@@ -22,43 +23,74 @@ export default function marshalFunction(
   // because Function.prototype.toString on a callable proxy never matches /^class/.
   // Computed once here rather than per call to avoid the toString + regex on every
   // VM→host invocation.
-  const isClass = isES2015Class(unwrap(target));
+  const unwrapped = unwrap(target);
+  const isClass = isES2015Class(unwrapped);
 
-  const raw = ctx
-    .newFunction(target.name, function (...argHandles) {
-      // A plain call (`fn()`) passes the VM global object as `this`. Unmarshalling
-      // it would eagerly deep-copy the entire global graph (hundreds of handles)
-      // on the first call, for a `this` host functions almost never use — and
-      // leaking globalThis to the host is undesirable. So global `this` is passed
-      // to the host function as `undefined`, which differs from plain JS where a
-      // non-strict function sees `this === globalThis` (see README Limitations).
-      // Real method calls still get their receiver unmarshalled.
-      const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
-      const args = argHandles.map(a => unmarshal(a));
+  // Marshal as an Asyncified function only when the caller opts in for this
+  // target AND the context actually supports it (a plain sync context has no
+  // `newAsyncifiedFunction`, so fall back to the normal function marshalling,
+  // which hands the guest a marshalled Promise as before).
+  const useAsyncify =
+    !!asyncify && asyncify(unwrapped) && "newAsyncifiedFunction" in ctx;
 
-      if (isClass && isObject(that)) {
-        // Class constructors cannot be invoked without new expression, and new.target is not changed
-        const result = new (target as new (...args: any[]) => any)(...args);
-        Object.entries(result).forEach(([key, value]) => {
-          const valueHandle = marshal(value);
-          ctx.setProp(this, key, valueHandle);
-          // setProp dup'd the value into `this`; drop ours if it was transient.
-          disposeTransient(valueHandle);
-        });
-        return this;
-      }
+  const raw = (
+    useAsyncify
+      ? // Asyncify: the VM stack is suspended until the host promise settles, so
+        // the guest receives the resolved value synchronously. Async functions
+        // can never be class constructors, so the class-constructor path is
+        // skipped here.
+        (ctx as QuickJSAsyncContext).newAsyncifiedFunction(target.name, async function (
+          ...argHandles
+        ) {
+          const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
+          const args = argHandles.map(a => unmarshal(a));
 
-      // The VM disposes whatever we return here. `prepareReturn` dups the
-      // handle when the VMMap retains it, so the map keeps a live copy and
-      // identity (`x === fn()` across calls) survives instead of going stale.
-      return prepareReturn(
-        marshal(
-          preApply
+          // `preApply` wraps the (synchronous) invocation to toggle temporal sync
+          // around it; it returns the host promise, which we await here. Note that
+          // its finally runs as soon as `apply` returns the promise, so temporal
+          // sync is only active for the synchronous portion of the async function,
+          // not across its awaits.
+          const result = await (preApply
             ? preApply(target as (...args: any[]) => any, that, args)
-            : (target as (...args: any[]) => any).apply(that, args),
-        ),
-      );
-    })
+            : (target as (...args: any[]) => any).apply(that, args));
+
+          return prepareReturn(marshal(result));
+        })
+      : ctx.newFunction(target.name, function (...argHandles) {
+          // A plain call (`fn()`) passes the VM global object as `this`. Unmarshalling
+          // it would eagerly deep-copy the entire global graph (hundreds of handles)
+          // on the first call, for a `this` host functions almost never use — and
+          // leaking globalThis to the host is undesirable. So global `this` is passed
+          // to the host function as `undefined`, which differs from plain JS where a
+          // non-strict function sees `this === globalThis` (see README Limitations).
+          // Real method calls still get their receiver unmarshalled.
+          const that = ctx.sameValue(this, ctx.global) ? undefined : unmarshal(this);
+          const args = argHandles.map(a => unmarshal(a));
+
+          if (isClass && isObject(that)) {
+            // Class constructors cannot be invoked without new expression, and new.target is not changed
+            const result = new (target as new (...args: any[]) => any)(...args);
+            Object.entries(result).forEach(([key, value]) => {
+              const valueHandle = marshal(value);
+              ctx.setProp(this, key, valueHandle);
+              // setProp dup'd the value into `this`; drop ours if it was transient.
+              disposeTransient(valueHandle);
+            });
+            return this;
+          }
+
+          // The VM disposes whatever we return here. `prepareReturn` dups the
+          // handle when the VMMap retains it, so the map keeps a live copy and
+          // identity (`x === fn()` across calls) survives instead of going stale.
+          return prepareReturn(
+            marshal(
+              preApply
+                ? preApply(target as (...args: any[]) => any, that, args)
+                : (target as (...args: any[]) => any).apply(that, args),
+            ),
+          );
+        })
+  )
     .consume(handle2 =>
       // fucntions created by vm.newFunction are not callable as a class constrcutor
       call(

--- a/src/marshal/index.ts
+++ b/src/marshal/index.ts
@@ -36,6 +36,11 @@ export type Options = {
   // Strip a host-side proxy wrapper from a target. Used to detect a wrapped class
   // constructor, which would otherwise be hidden behind the proxy. Defaults to identity.
   unwrap?: (target: unknown) => unknown;
+  // Decide whether a host function should be marshalled as an Asyncified function
+  // (the VM suspends until the host promise settles, so the guest gets the
+  // resolved value synchronously). Called with the unwrapped target. Only takes
+  // effect when the context supports `newAsyncifiedFunction`.
+  asyncify?: (target: unknown) => boolean;
   custom?: Iterable<(obj: unknown, ctx: QuickJSContext) => QuickJSHandle | undefined>;
 };
 
@@ -91,6 +96,7 @@ export function marshal(target: unknown, options: Options): QuickJSHandle {
       disposeTransient,
       options.prepareReturn,
       options.unwrap,
+      options.asyncify,
     ) ??
     marshalMapSet(ctx, target, marshal2, pre2, disposeTransient) ??
     marshalObject(ctx, target, marshal2, pre2, disposeTransient) ??


### PR DESCRIPTION
Supersedes #97 — identical diff, rebased onto main after the stack (#93→#94→#95, #96) landed as squash merges, which left #97's merge base stale and conflicting. No content changes; 184 tests / typecheck / lint verified on the rebased branch.

Adds an `asyncify` Arena option (`boolean | predicate`). When enabled on a `QuickJSAsyncContext` (AsyncArena), matching host functions are marshalled via `newAsyncifiedFunction`, so the guest receives the resolved value synchronously (the VM suspends until the host promise settles) instead of a marshalled Promise. `true` auto-detects declared async functions; transpiled async functions need the predicate form. Falls back silently to Promise marshalling on sync contexts.

Documented constraints:
- Only works when evaluation enters through an async entry point (`AsyncArena.evalCodeAsync`); a synchronous `evalCode` fails with `Error: Function unexpectedly returned a Promise`.
- Emscripten Asyncify allows one suspended call at a time.
- Silently ignored on contexts without `newAsyncifiedFunction`.

Closes #32