### PR TITLE
fix: dispose orphaned handles when an abort interrupts marshalling mid-flight

### DIFF
--- a/src/contextex.ts
+++ b/src/contextex.ts
@@ -1,5 +1,7 @@
 import { QuickJSContext, QuickJSHandle, VmFunctionImplementation } from "quickjs-emscripten";
 
+import { consumeAll } from "./vmutil";
+
 export type QuickJSContextEx = QuickJSContext & {
   disposeEx?: () => void;
 };
@@ -51,15 +53,25 @@ export class ContextEx {
     this.fnCounter++;
     const id = this.fnCounter;
     this.fnMap.set(id, fn);
-    return this.context.unwrapResult(
-      this.context.callFunction(
-        this.fnGenerator,
-        this.context.undefined,
+    // `callFunction` does not dispose its arguments, so the name/length/id handles
+    // are consumed here (even on throw) instead of leaking on every newFunction.
+    return consumeAll(
+      [
         this.context.newString(name),
         this.context.newNumber(fn.length),
         this.context.newNumber(id),
-        this.fn,
-      ),
+      ],
+      ([nameHandle, lengthHandle, idHandle]) =>
+        this.context.unwrapResult(
+          this.context.callFunction(
+            this.fnGenerator,
+            this.context.undefined,
+            nameHandle,
+            lengthHandle,
+            idHandle,
+            this.fn,
+          ),
+        ),
     );
   };
 }

--- a/src/faultinjection.test.ts
+++ b/src/faultinjection.test.ts
@@ -1,0 +1,265 @@
+import variant from "@jitl/quickjs-wasmfile-debug-sync";
+import { newQuickJSWASMModuleFromVariant, type QuickJSWASMModule } from "quickjs-emscripten";
+import { describe, expect, test } from "vitest";
+
+import { Arena } from ".";
+
+// Deterministic fault-injection harness for issue #88.
+//
+// When a hard abort (memory limit or interrupt) lands *mid-flight* in the deep
+// sync/marshal/unmarshal chain, a host-held QuickJS handle can be orphaned. The
+// debug-sync runtime aborts on `ctx.dispose()` (a C-level `RuntimeError`) if any
+// GC object handle leaked (`Assertion failed: list_empty(&rt->gc_obj_list) ... at
+// JS_FreeRuntime`). That abort IS the detector: a scenario is run under an
+// injected fault, then `arena.dispose()` + `ctx.dispose()` must NOT throw. A
+// throw means a handle was orphaned.
+//
+// We deliberately use the debug-sync variant (not `getQuickJS()`): only the debug
+// build asserts the GC object list is empty at `JS_FreeRuntime`, and that
+// assertion is what surfaces the leak. This mirrors the sibling leak tests
+// (jsonleak/remarshalleak).
+//
+// Two injection mechanisms:
+//
+// A. Memory-limit sweep — `arena.setMemoryLimit(limit)` makes any VM allocation
+//    (`ctx.new*` / `callFunction`) fail once the working set crosses `limit`, so
+//    the abort lands at an allocation deep in the host-driven marshal/unmarshal
+//    chain. Swept over a fixed byte range that brackets each scenario's working
+//    set. The step (320) is chosen to match the range used while developing the
+//    fix: a *finer* step occasionally lands the OOM on an exact byte that trips a
+//    pre-existing quickjs-emscripten hang (an OOM inside its GC that never
+//    returns control — unrelated to handle leaks, and unfixable host-side). The
+//    step here is verified hang-free for these payloads, and, because the WASM is
+//    deterministic, that holds in CI too.
+//
+// B. Interrupt sweep — `arena.setInterruptHandler` fires only during VM bytecode
+//    execution, so it cannot land in the *host-side* marshal code that the
+//    memory sweep targets (a direct `expose`/`evalCode` never invokes the
+//    handler — its VM work is below the interrupt-check interval). To exercise
+//    the boundary under interrupts we drive it from *inside* a VM loop: a synced
+//    mutation loop and a host-function round-trip loop repeatedly cross into the
+//    marshal/unmarshal chain, and the interrupt can trip inside a nested VM
+//    `call` there. A counter-based handler interrupts on its Nth invocation; N is
+//    swept until a run completes uninterrupted.
+
+class Point {
+  x: number;
+  y: number;
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+  dist() {
+    return Math.hypot(this.x, this.y);
+  }
+}
+
+// A payload that crosses every marshal path: primitives, arrays, Date & Symbol
+// (custom), a function, a class instance (custom prototype + method), Map & Set
+// (mapset), and nesting.
+const richHost = () => ({
+  n: 42,
+  s: "hi",
+  arr: [1, 2, 3],
+  d: new Date(0),
+  sym: Symbol("k"),
+  fn: (a: number, b: number) => a + b,
+  pt: new Point(3, 4),
+  m: new Map<string, number>([
+    ["a", 1],
+    ["b", 2],
+  ]),
+  set: new Set<number>([7, 8, 9]),
+  nested: { a: { b: [{ c: 1 }] } },
+});
+
+const scenarios: Record<string, (arena: Arena) => void> = {
+  // 1. Mutating a synced object from the VM (the known-bad case from the issue):
+  //    the abort is swept through the sync -> marshal -> setter chain.
+  syncedMutation: arena => {
+    const s: any = arena.sync({ a: { b: 1 } });
+    arena.expose({ s });
+    arena.evalCode(`s.a.b = { deep: [1, 2, 3] }`);
+  },
+  // 2. Marshal chain: expose a nested object/function mix.
+  marshal: arena => {
+    arena.expose({ obj: richHost() });
+    arena.evalCode(`obj.pt.x + obj.arr[1] + obj.m.get("a") + obj.set.size`);
+  },
+  // 3. Unmarshal chain: evaluate a deep object literal with functions/arrays. It
+  //    deliberately avoids holding BOTH a Map and a Set in one unmarshalled
+  //    literal, which trips the pre-existing quickjs OOM hang described above;
+  //    the mapset *marshal* path is covered by scenarios 2 and 4 instead.
+  unmarshal: arena => {
+    arena.evalCode(
+      `({ n: 1, s: "x", arr: [1, 2, { z: 3 }], d: new Date(0), fn: a => a * 2, nested: { a: { b: { c: [4, 5] } } }, sym: Symbol("q") })`,
+    );
+  },
+  // 4. Round-trip: an exposed host function called from the VM with an object
+  //    argument (unmarshal) and an object return (marshal, incl. Date/Symbol/Set).
+  roundTrip: arena => {
+    arena.expose({
+      host: (o: any) => ({
+        sum: o.a + o.b,
+        when: new Date(0),
+        tag: Symbol("r"),
+        items: [o.a, o.b],
+        pt: new Point(o.a, o.b),
+        tags: new Set([o.a]),
+      }),
+    });
+    arena.evalCode(`host({ a: 1, b: 2 }).sum`);
+  },
+};
+
+async function newModule(): Promise<QuickJSWASMModule> {
+  return newQuickJSWASMModuleFromVariant(variant as any);
+}
+
+function newArena(mod: QuickJSWASMModule) {
+  const ctx = mod.newContext();
+  return { ctx, arena: new Arena(ctx, { isMarshalable: true }) };
+}
+
+// Dispose the arena then the context; report whether the C-level GC assertion
+// aborted (which surfaces as a thrown RuntimeError). A leaked handle => true.
+function disposeAborted(arena: Arena, ctx: ReturnType<QuickJSWASMModule["newContext"]>): boolean {
+  try {
+    arena.dispose();
+    ctx.dispose();
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+// Sweep the memory limit across [lo, hi]; return the limits at which dispose
+// aborted plus how many runs failed vs. succeeded (to confirm the range brackets
+// the scenario's working set). A recreated module isolates any abort so the
+// sweep can enumerate every offending limit.
+async function memoryLimitSweep(run: (arena: Arena) => void) {
+  const lo = 8000;
+  const hi = 14000;
+  const step = 320;
+  let mod = await newModule();
+  const reds: number[] = [];
+  let failed = 0;
+  let succeeded = 0;
+  for (let limit = lo; limit <= hi; limit += step) {
+    const { ctx, arena } = newArena(mod);
+    let threw = false;
+    arena.setMemoryLimit(limit);
+    try {
+      run(arena);
+    } catch {
+      threw = true;
+    }
+    // Reset before teardown so disposal (which allocates, e.g. to clear the map)
+    // is not itself starved by the limit.
+    arena.setMemoryLimit(-1);
+    if (threw) failed++;
+    else succeeded++;
+    if (disposeAborted(arena, ctx)) {
+      reds.push(limit);
+      mod = await newModule();
+    }
+  }
+  return { reds, failed, succeeded };
+}
+
+// Sweep the interrupt threshold N = 1, 2, ... until a run completes without the
+// handler firing N times (i.e. the whole loop ran with fewer than N interrupt
+// checks), which means every interruptible depth has been covered.
+async function interruptSweep(setup: (arena: Arena) => void, body: string, cap = 100) {
+  let mod = await newModule();
+  const reds: number[] = [];
+  let fullCount = -1;
+  for (let n = 1; n <= cap; n++) {
+    const { ctx, arena } = newArena(mod);
+    setup(arena);
+    let count = 0;
+    arena.setInterruptHandler(() => ++count === n);
+    try {
+      arena.evalCode(body);
+    } catch {
+      // any thrown Error is acceptable
+    }
+    arena.removeInterruptHandler();
+    if (disposeAborted(arena, ctx)) {
+      reds.push(n);
+      mod = await newModule();
+    }
+    if (count < n) {
+      // The run finished before the handler reached N: all depths swept.
+      fullCount = count;
+      break;
+    }
+  }
+  return { reds, fullCount, capHit: fullCount < 0 };
+}
+
+describe("fault injection: memory-limit sweep leaves no orphaned handle", () => {
+  for (const [name, run] of Object.entries(scenarios)) {
+    test(
+      `${name}`,
+      async () => {
+        const { reds, failed, succeeded } = await memoryLimitSweep(run);
+        // The range must bracket the working set (some limits fail mid-flight,
+        // some succeed) or the sweep would not be injecting faults at all.
+        expect(failed, `scenario "${name}": no memory limit forced a mid-flight failure`).toBeGreaterThan(0);
+        expect(succeeded, `scenario "${name}": no memory limit let the run complete`).toBeGreaterThan(0);
+        expect(
+          reds,
+          `scenario "${name}": ctx.dispose() aborted (a GC handle leaked) at memory limit(s) ${reds.join(", ")}`,
+        ).toEqual([]);
+      },
+      30000,
+    );
+  }
+});
+
+describe("fault injection: interrupt sweep leaves no orphaned handle", () => {
+  // Loop-driven forms so the VM interrupt actually lands in the marshal/unmarshal
+  // chain (see header). Each asserts the interrupt genuinely fired (fullCount > 0)
+  // and that no swept threshold orphaned a handle.
+  test(
+    "synced mutation loop",
+    async () => {
+      const { reds, fullCount, capHit } = await interruptSweep(
+        arena => {
+          const s: any = arena.sync({ a: { b: 0 } });
+          arena.expose({ s });
+        },
+        `for (let i = 0; i < 100; i++) { s.a.b = { deep: [i, i + 1], when: new Date(i) }; }`,
+      );
+      expect(capHit, "interrupt handler never stopped firing; raise the cap").toBe(false);
+      expect(fullCount, "interrupt never fired; the scenario does not exercise mechanism B").toBeGreaterThan(0);
+      expect(reds, `dispose aborted (a GC handle leaked) at interrupt threshold(s) ${reds.join(", ")}`).toEqual([]);
+    },
+    30000,
+  );
+
+  test(
+    "host round-trip loop",
+    async () => {
+      const { reds, fullCount, capHit } = await interruptSweep(
+        arena => {
+          arena.expose({
+            host: (o: any) => ({
+              sum: o.a + o.b,
+              when: new Date(0),
+              tag: Symbol("r"),
+              items: [o.a, o.b],
+              pt: new Point(o.a, o.b),
+            }),
+          });
+        },
+        `let acc = 0; for (let i = 0; i < 150; i++) { acc += host({ a: i, b: 1 }).sum; } acc`,
+      );
+      expect(capHit, "interrupt handler never stopped firing; raise the cap").toBe(false);
+      expect(fullCount, "interrupt never fired; the scenario does not exercise mechanism B").toBeGreaterThan(0);
+      expect(reds, `dispose aborted (a GC handle leaked) at interrupt threshold(s) ${reds.join(", ")}`).toEqual([]);
+    },
+    30000,
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -661,15 +661,29 @@ export class Arena {
       if (ref) return ref.value;
     }
 
-    const [wrappedHandle] = this._wrapHandle(handle);
-    return unmarshal(wrappedHandle ?? handle, {
-      ctx: this.context,
-      marshal: this._marshal,
-      find: this._unmarshalFind,
-      pre: this._preUnmarshal,
-      custom: this._options?.customUnmarshaller,
-      hostRef: !!this._options?.marshalByReference,
-    });
+    const [wrappedHandle, wrapped] = this._wrapHandle(handle);
+    let done = false;
+    try {
+      const result = unmarshal(wrappedHandle ?? handle, {
+        ctx: this.context,
+        marshal: this._marshal,
+        find: this._unmarshalFind,
+        pre: this._preUnmarshal,
+        custom: this._options?.customUnmarshaller,
+        hostRef: !!this._options?.marshalByReference,
+      });
+      done = true;
+      return result;
+    } finally {
+      // A mid-flight abort (e.g. an OOM inside the unmarshal chain) can throw
+      // before the freshly created proxy handle was registered in the map,
+      // orphaning it. Dispose it here; if it was already registered the map
+      // skips it (alive check) at dispose. Disposing a handle never allocates,
+      // so this is safe even under an active memory limit.
+      if (!done && wrapped && wrappedHandle?.alive && wrappedHandle !== handle) {
+        wrappedHandle.dispose();
+      }
+    }
   };
 
   _register(
@@ -683,24 +697,41 @@ export class Arena {
     }
 
     let wrappedT = this._wrap(t);
-    const [wrappedH] = this._wrapHandle(h);
+    // `wrappedHNew` is true when `_wrapHandle` allocated a fresh VM proxy (which
+    // we own) rather than returning the original handle. If registration fails
+    // or throws mid-flight (e.g. an OOM in `map.set`), that proxy would be
+    // orphaned, so the finally below disposes it.
+    const [wrappedH, wrappedHNew] = this._wrapHandle(h);
     const isPromise = t instanceof Promise;
     if (!wrappedH || (!wrappedT && !isPromise)) return; // t or h is not an object
     if (isPromise) wrappedT = t;
 
     const unwrappedT = this._unwrap(t);
-    const [unwrappedH, unwrapped] = this._unwrapHandle(h);
+    let unwrappedH: QuickJSHandle | undefined;
+    let unwrapped = false;
+    let done = false;
+    try {
+      [unwrappedH, unwrapped] = this._unwrapHandle(h);
 
-    const res = map.set(wrappedT, wrappedH, unwrappedT, unwrappedH);
-    if (!res) {
-      // already registered
-      if (unwrapped) unwrappedH.dispose();
-      throw new Error("already registered");
-    } else if (sync) {
-      this._sync.add(unwrappedT);
+      const res = map.set(wrappedT, wrappedH, unwrappedT, unwrappedH);
+      if (!res) {
+        // already registered
+        throw new Error("already registered");
+      } else if (sync) {
+        this._sync.add(unwrappedT);
+      }
+
+      done = true;
+      return [wrappedT, wrappedH];
+    } finally {
+      if (!done) {
+        // `map.set` did not take ownership (it threw or returned false): dispose
+        // the handles we created so they are not orphaned. A non-new `wrappedH`
+        // and a non-wrapped `unwrappedH` are the caller's handle `h`, left alone.
+        if (wrappedHNew && wrappedH.alive) wrappedH.dispose();
+        if (unwrapped && unwrappedH?.alive) unwrappedH.dispose();
+      }
     }
-
-    return [wrappedT, wrappedH];
   }
 
   _syncMode = (obj: any): "both" | undefined => {

--- a/src/marshal/custom.ts
+++ b/src/marshal/custom.ts
@@ -1,6 +1,6 @@
 import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
 
-import { call, consumeAll } from "../vmutil";
+import { call, consume, consumeAll } from "../vmutil";
 
 export default function marshalCustom(
   ctx: QuickJSContext,
@@ -13,24 +13,33 @@ export default function marshalCustom(
     handle = c(target, ctx);
     if (handle) break;
   }
-  return handle ? preMarshal(target, handle) ?? handle : undefined;
+  if (!handle) return undefined;
+  // Own the custom-marshalled handle until `preMarshal` registers it; dispose it
+  // if `preMarshal` throws mid-flight so it is not orphaned.
+  let owned = true;
+  try {
+    const result = preMarshal(target, handle) ?? handle;
+    owned = false;
+    return result;
+  } finally {
+    if (owned && handle.alive) handle.dispose();
+  }
 }
 
 export function symbol(target: unknown, ctx: QuickJSContext): QuickJSHandle | undefined {
   if (typeof target !== "symbol") return;
-  const handle = call(
-    ctx,
-    "d => Symbol(d)",
-    undefined,
-    target.description ? ctx.newString(target.description) : ctx.undefined,
-  );
-  return handle;
+  // `call` does not dispose its arguments, so the description string handle must
+  // be consumed here or it leaks on every symbol marshal.
+  return target.description
+    ? consume(ctx.newString(target.description), d => call(ctx, "d => Symbol(d)", undefined, d))
+    : call(ctx, "d => Symbol(d)", undefined, ctx.undefined);
 }
 
 export function date(target: unknown, ctx: QuickJSContext): QuickJSHandle | undefined {
   if (!(target instanceof Date)) return;
-  const handle = call(ctx, "d => new Date(d)", undefined, ctx.newNumber(target.getTime()));
-  return handle;
+  // `call` does not dispose its arguments, so the time number handle is consumed
+  // here rather than leaked.
+  return consume(ctx.newNumber(target.getTime()), d => call(ctx, "d => new Date(d)", undefined, d));
 }
 
 export function arrayBuffer(target: unknown, ctx: QuickJSContext): QuickJSHandle | undefined {

--- a/src/marshal/function.ts
+++ b/src/marshal/function.ts
@@ -1,7 +1,7 @@
 import type { QuickJSAsyncContext, QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
 
 import { isES2015Class, isObject } from "../util";
-import { call } from "../vmutil";
+import { call, consume } from "../vmutil";
 
 import marshalProperties from "./properties";
 
@@ -33,7 +33,7 @@ export default function marshalFunction(
   const useAsyncify =
     !!asyncify && asyncify(unwrapped) && "newAsyncifiedFunction" in ctx;
 
-  const raw = (
+  const inner = (
     useAsyncify
       ? // Asyncify: the VM stack is suspended until the host promise settles, so
         // the guest receives the resolved value synchronously. Async functions
@@ -90,24 +90,34 @@ export default function marshalFunction(
             ),
           );
         })
-  )
-    .consume(handle2 =>
-      // fucntions created by vm.newFunction are not callable as a class constrcutor
-      call(
-        ctx,
-        `Cls => {
-          const fn = function(...args) { return Cls.apply(this, args); };
-          fn.name = Cls.name;
-          fn.length = Cls.length;
-          return fn;
-        }`,
-        undefined,
-        handle2,
-      ),
-    );
+  );
 
-  const handle = preMarshal(target, raw) ?? raw;
-  marshalProperties(ctx, target, raw, marshal, disposeTransient);
+  // `consume` disposes the raw newFunction handle even if `call` throws (the raw
+  // `Lifetime.consume` would skip disposal on throw, leaking the function handle).
+  const raw = consume(inner, handle2 =>
+    // functions created by vm.newFunction are not callable as a class constructor
+    call(
+      ctx,
+      `Cls => {
+        const fn = function(...args) { return Cls.apply(this, args); };
+        fn.name = Cls.name;
+        fn.length = Cls.length;
+        return fn;
+      }`,
+      undefined,
+      handle2,
+    ),
+  );
 
-  return handle;
+  // Own `raw` until `preMarshal` registers it; dispose it if `preMarshal` throws
+  // mid-flight so the wrapped function handle is not orphaned.
+  let ownRaw = true;
+  try {
+    const handle = preMarshal(target, raw) ?? raw;
+    ownRaw = false;
+    marshalProperties(ctx, target, raw, marshal, disposeTransient);
+    return handle;
+  } finally {
+    if (ownRaw && raw.alive) raw.dispose();
+  }
 }

--- a/src/marshal/mapset.ts
+++ b/src/marshal/mapset.ts
@@ -11,27 +11,41 @@ export default function marshalMapSet(
 ): QuickJSHandle | undefined {
   if (target instanceof Map) {
     const raw = call(ctx, "() => new Map()");
-    const handle = preMarshal(target, raw) ?? raw;
-    for (const [k, v] of target) {
-      const kh = marshal(k);
-      const vh = marshal(v);
-      call(ctx, "(m, k, v) => m.set(k, v)", undefined, raw, kh, vh).dispose();
-      // set() has taken its own references; drop ours if they were transient.
-      disposeTransient(kh);
-      disposeTransient(vh);
+    // Own `raw` until `preMarshal` registers it; dispose it if `preMarshal`
+    // throws mid-flight so the fresh Map handle is not orphaned.
+    let ownRaw = true;
+    try {
+      const handle = preMarshal(target, raw) ?? raw;
+      ownRaw = false;
+      for (const [k, v] of target) {
+        const kh = marshal(k);
+        const vh = marshal(v);
+        call(ctx, "(m, k, v) => m.set(k, v)", undefined, raw, kh, vh).dispose();
+        // set() has taken its own references; drop ours if they were transient.
+        disposeTransient(kh);
+        disposeTransient(vh);
+      }
+      return handle;
+    } finally {
+      if (ownRaw && raw.alive) raw.dispose();
     }
-    return handle;
   }
 
   if (target instanceof Set) {
     const raw = call(ctx, "() => new Set()");
-    const handle = preMarshal(target, raw) ?? raw;
-    for (const v of target) {
-      const vh = marshal(v);
-      call(ctx, "(s, v) => s.add(v)", undefined, raw, vh).dispose();
-      // add() has taken its own reference; drop ours if it was transient.
-      disposeTransient(vh);
+    let ownRaw = true;
+    try {
+      const handle = preMarshal(target, raw) ?? raw;
+      ownRaw = false;
+      for (const v of target) {
+        const vh = marshal(v);
+        call(ctx, "(s, v) => s.add(v)", undefined, raw, vh).dispose();
+        // add() has taken its own reference; drop ours if it was transient.
+        disposeTransient(vh);
+      }
+      return handle;
+    } finally {
+      if (ownRaw && raw.alive) raw.dispose();
     }
-    return handle;
   }
 }

--- a/src/marshal/object.ts
+++ b/src/marshal/object.ts
@@ -14,21 +14,30 @@ export default function marshalObject(
   if (typeof target !== "object" || target === null) return;
 
   const raw = Array.isArray(target) ? ctx.newArray() : ctx.newObject();
-  const handle = preMarshal(target, raw) ?? raw;
+  // We own `raw` until `preMarshal` registers it (in the map or the transient
+  // set) or returns it as `handle`. If `preMarshal` throws mid-flight (e.g. an
+  // OOM while creating the proxy), dispose `raw` so it is not orphaned.
+  let ownRaw = true;
+  try {
+    const handle = preMarshal(target, raw) ?? raw;
+    ownRaw = false;
 
-  // prototype
-  const prototype = Object.getPrototypeOf(target);
-  const prototypeHandle =
-    prototype && prototype !== Object.prototype && prototype !== Array.prototype
-      ? marshal(prototype)
-      : undefined;
-  if (prototypeHandle) {
-    call(ctx, "Object.setPrototypeOf", undefined, handle, prototypeHandle).dispose();
-    // setPrototypeOf has taken its own reference; drop ours if it was transient.
-    disposeTransient(prototypeHandle);
+    // prototype
+    const prototype = Object.getPrototypeOf(target);
+    const prototypeHandle =
+      prototype && prototype !== Object.prototype && prototype !== Array.prototype
+        ? marshal(prototype)
+        : undefined;
+    if (prototypeHandle) {
+      call(ctx, "Object.setPrototypeOf", undefined, handle, prototypeHandle).dispose();
+      // setPrototypeOf has taken its own reference; drop ours if it was transient.
+      disposeTransient(prototypeHandle);
+    }
+
+    marshalProperties(ctx, target, raw, marshal, disposeTransient);
+
+    return handle;
+  } finally {
+    if (ownRaw && raw.alive) raw.dispose();
   }
-
-  marshalProperties(ctx, target, raw, marshal, disposeTransient);
-
-  return handle;
 }

--- a/src/marshal/promise.ts
+++ b/src/marshal/promise.ts
@@ -9,11 +9,19 @@ export default function marshalPromise(
   if (!(target instanceof Promise)) return;
 
   const promise = ctx.newPromise();
+  // Own the deferred promise until `preMarshal` registers it; dispose it (handle
+  // plus resolve/reject callbacks) if `preMarshal` throws mid-flight.
+  let owned = true;
+  try {
+    target.then(
+      d => promise.resolve(marshal(d)),
+      d => promise.reject(marshal(d)),
+    );
 
-  target.then(
-    d => promise.resolve(marshal(d)),
-    d => promise.reject(marshal(d)),
-  );
-
-  return preMarshal(target, promise) ?? promise.handle;
+    const result = preMarshal(target, promise) ?? promise.handle;
+    owned = false;
+    return result;
+  } finally {
+    if (owned && promise.alive) promise.dispose();
+  }
 }

--- a/src/marshal/properties.ts
+++ b/src/marshal/properties.ts
@@ -1,6 +1,6 @@
 import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
 
-import { call } from "../vmutil";
+import { call, consume } from "../vmutil";
 
 export default function marshalProperties(
   ctx: QuickJSContext,
@@ -67,7 +67,9 @@ export default function marshalProperties(
     if (setHandle) transient.push(setHandle);
 
     const descsHandle = (descs ??= ctx.newObject());
-    ctx.newObject().consume(descObj => {
+    // `consume` disposes the descriptor object even if a `setProp` throws
+    // mid-flight, so the intermediate handle is not orphaned.
+    consume(ctx.newObject(), descObj => {
       Object.entries(desc).forEach(([k, v]) => {
         const v2 =
           k === "value"

--- a/src/unmarshal/mapset.ts
+++ b/src/unmarshal/mapset.ts
@@ -21,18 +21,33 @@ export default function unmarshalMapSet(
     for (const elResult of iterator) {
       const el = ctx.unwrapResult(elResult);
       if (isMap) {
+        // `disposeKey`/`disposeValue` start true so a mid-flight throw (e.g. OOM
+        // inside `unmarshal`) disposes the property handles instead of orphaning
+        // them; on success they are disposed only when redundant (already owned).
         const keyHandle = ctx.getProp(el, 0);
         const valueHandle = ctx.getProp(el, 1);
-        const [key, disposeKey] = unmarshal(keyHandle);
-        const [value, disposeValue] = unmarshal(valueHandle);
-        if (disposeKey) keyHandle.dispose();
-        if (disposeValue) valueHandle.dispose();
-        (result as Map<any, any>).set(key, value);
-        el.dispose();
+        let disposeKey = true;
+        let disposeValue = true;
+        try {
+          const [key, dk] = unmarshal(keyHandle);
+          disposeKey = dk;
+          const [value, dv] = unmarshal(valueHandle);
+          disposeValue = dv;
+          (result as Map<any, any>).set(key, value);
+        } finally {
+          if (disposeKey && keyHandle.alive) keyHandle.dispose();
+          if (disposeValue && valueHandle.alive) valueHandle.dispose();
+          if (el.alive) el.dispose();
+        }
       } else {
-        const [value, disposeValue] = unmarshal(el);
-        if (disposeValue) el.dispose();
-        (result as Set<any>).add(value);
+        let disposeValue = true;
+        try {
+          const [value, dv] = unmarshal(el);
+          disposeValue = dv;
+          (result as Set<any>).add(value);
+        } finally {
+          if (disposeValue && el.alive) el.dispose();
+        }
       }
     }
   } finally {

--- a/src/unmarshal/promise.ts
+++ b/src/unmarshal/promise.ts
@@ -1,7 +1,7 @@
 import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
 
 import { newDeferred } from "../util";
-import { call, instanceOf } from "../vmutil";
+import { call, consume, instanceOf } from "../vmutil";
 
 export default function unmarshalPromise<T = unknown>(
   ctx: QuickJSContext,
@@ -24,7 +24,11 @@ export default function unmarshalPromise<T = unknown>(
 
 function isPromiseHandle(ctx: QuickJSContext, handle: QuickJSHandle): boolean {
   if (!handle.owner) return false;
-  return ctx.unwrapResult(ctx.evalCode("Promise")).consume(promise => {
+  // `consume` disposes the Promise constructor handle even if `instanceOf`
+  // throws mid-flight (e.g. an interrupt or OOM lands in the `a instanceof b`
+  // VM call); the raw `Lifetime.consume` would skip disposal on throw, orphaning
+  // the constructor handle.
+  return consume(ctx.unwrapResult(ctx.evalCode("Promise")), promise => {
     if (!handle.owner) return false;
     return instanceOf(ctx, handle, promise);
   });

--- a/src/unmarshal/properties.ts
+++ b/src/unmarshal/properties.ts
@@ -65,9 +65,18 @@ export default function unmarshalProperties(
       // otherwise ownership was transferred to the map and we must keep it.
       const readHandle = (fieldKey: string): unknown => {
         const h = ctx.getProp(descHandle, fieldKey);
-        const [v, alreadyExists] = unmarshal(h);
-        if (alreadyExists) h.dispose();
-        return v;
+        let retained = false;
+        try {
+          const [v, alreadyExists] = unmarshal(h);
+          // When the value already existed, ownership stays with the map and the
+          // fresh handle is redundant; otherwise `unmarshal` transferred it to the
+          // map and we must keep it. A mid-flight throw in `unmarshal` also lands
+          // here with `retained` false, so the orphaned handle is disposed.
+          retained = !alreadyExists;
+          return v;
+        } finally {
+          if (!retained && h.alive) h.dispose();
+        }
       };
 
       if (flags & 1) desc.value = readHandle("value");

--- a/src/vmmap.ts
+++ b/src/vmmap.ts
@@ -1,6 +1,6 @@
 import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten";
 
-import { unwrapResult } from "./vmutil";
+import { consume, unwrapResult } from "./vmutil";
 
 /**
  * Bidirectional map between host values and QuickJS handles.
@@ -79,7 +79,19 @@ export default class VMMap {
       return v === handle || v === handle2;
     }
 
-    const id = this._nextId++;
+    const id = this._nextId;
+
+    // Register on the VM side FIRST, before mutating any host-side bookkeeping.
+    // If this throws (e.g. an OOM lands inside `_mapSet`), no host map has been
+    // touched and `handle`/`handle2` are NOT retained here, so the caller still
+    // owns them and can dispose them: `set` stays atomic (all-or-nothing).
+    // `consume` disposes the id number handle even when the call throws (the raw
+    // `Lifetime.consume` skips disposal on throw, leaking it).
+    consume(this.ctx.newNumber(id), c => {
+      this._call(this._mapSet, undefined, handle, c, handle2 ?? this.ctx.undefined);
+    });
+
+    this._nextId++;
     this._keyToId.set(key, id);
     this._idToHandle.set(id, handle);
     this._idToKey.set(id, key);
@@ -90,10 +102,6 @@ export default class VMMap {
         this._idToHandle2.set(id, handle2);
       }
     }
-
-    this.ctx.newNumber(id).consume(c => {
-      this._call(this._mapSet, undefined, handle, c, handle2 ?? this.ctx.undefined);
-    });
 
     return true;
   }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,7 +1,7 @@
 import type { QuickJSHandle, QuickJSContext } from "quickjs-emscripten";
 
 import { isObject } from "./util";
-import { call, isHandleObject, mayConsumeAll } from "./vmutil";
+import { call, consume, isHandleObject, mayConsumeAll } from "./vmutil";
 
 export type SyncMode = "both" | "vm" | "host";
 
@@ -54,7 +54,8 @@ export function wrap<T = any>(
         (receiverHandle, keyHandle, valueHandle) => {
           const [handle2, unwrapped] = unwrapHandle(ctx, receiverHandle, proxyKeySymbolHandle);
           if (unwrapped) {
-            handle2.consume(h => ctx.setProp(h, keyHandle, valueHandle));
+            // `consume` disposes the unwrapped handle even if `setProp` throws.
+            consume(handle2, h => ctx.setProp(h, keyHandle, valueHandle));
           } else {
             ctx.setProp(handle2, keyHandle, valueHandle);
           }
@@ -72,7 +73,8 @@ export function wrap<T = any>(
           if (sync === "host" || !ctx.alive) return true;
 
           if (unwrapped) {
-            handle2.consume(h => call(ctx, `(a, b) => delete a[b]`, undefined, h, keyHandle));
+            // `consume` disposes the unwrapped handle even if the call throws.
+            consume(handle2, h => call(ctx, `(a, b) => delete a[b]`, undefined, h, keyHandle));
           } else {
             call(ctx, `(a, b) => delete a[b]`, undefined, handle2, keyHandle);
           }
@@ -103,7 +105,8 @@ export function wrap<T = any>(
               keyHandle,
               descHandle,
             ).dispose();
-          if (unwrapped) handle2.consume(define);
+          // `consume` disposes the unwrapped handle even if `define` throws.
+          if (unwrapped) consume(handle2, define);
           else define(handle2);
         },
       );


### PR DESCRIPTION
## Summary

A deterministic fault-injection harness (`src/faultinjection.test.ts`) sweeps mid-flight aborts through the marshal/unmarshal/sync chains two ways — memory-limit sweep (`setMemoryLimit`, limits 8000–14000 step 320) and interrupt sweep (`setInterruptHandler` firing at the Nth checkpoint, driven through VM loops so interrupts land inside nested calls) — across 4 scenarios (synced mutation, marshal, unmarshal, host-fn round-trip) with payloads crossing the symbol/Date/array/function/class/Map/Set paths. Detector: the debug-sync wasm variant's `JS_FreeRuntime` GC-list assertion; every sweep point must survive `arena.dispose()` + `ctx.dispose()` without aborting.

Before the fixes the harness was red at 30+ sweep points across all 4 scenarios; now all green.

## Leak sites fixed

- marshal object/mapset/function/promise/custom raw handles orphaned when `preMarshal` throws
- `unmarshal/properties` value handle on mid-unmarshal throw
- `unmarshal/mapset` key/value handles
- `unmarshal/promise` Promise-constructor handle when `instanceOf` is interrupted
- `Arena._register`/`_unmarshal` proxy handles on registration throw
- `VMMap.set` made atomic (VM-side registration first, exception-safe consume of the id handle)
- `wrapper.ts` trap receivers and `marshal/properties` descObj raw `.consume` → exception-safe
- `contextex.ts` newFunction arg handles
- `marshal/custom.ts` symbol/date argument handles (also a normal-path leak)

## Known residue (documented, host-side unfixable)

A pre-existing quickjs-emscripten hang: if a hard OOM lands on a specific allocation while unmarshalling a VM object holding BOTH a Map and a Set, quickjs loops forever inside GC and never returns (reproducible on unmodified main, so unrelated to these fixes; it is a hang, not a handle leak, and cannot be caught host-side). The harness avoids that pathological payload/step combination deliberately (wasm is deterministic, so CI-safe). Candidate for an upstream report to quickjs-emscripten.

## Verification

190 tests (6 new sweeps, ~40s added) / typecheck / lint pass; bench A/C/F unchanged within noise.

Fixes #88